### PR TITLE
The mergening

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -91,6 +91,9 @@
           <li>
             <%= link_to 'Wiki', "https://github.com/rails-oceania/roro/wiki" %>
           </li>
+          <li>
+            <%= link_to 'Rails Girls', "/rails-girls" %>
+          </li>
         </ul>
       </nav>
     </aside>

--- a/app/views/pages/association.html.erb
+++ b/app/views/pages/association.html.erb
@@ -48,6 +48,9 @@
       <h3>Committee Meeting Minutes</h3>
       <ul>
         <li>
+          <%= link_to "March 15 2016 (Online Webinar)", '/committee_meetings/2016-03-15.html' %>
+        </li>
+        <li>
           <%= link_to "January 12 2016 (Online Webinar)", "/committee_meetings/2016-01-12.html" %>
         </li>
         <li>

--- a/app/views/pages/association.html.erb
+++ b/app/views/pages/association.html.erb
@@ -28,6 +28,9 @@
       <h3>Special General Meeting Minutes</h3>
       <ul>
         <li>
+          <%= link_to "July 10 2016 (Rails Camp 19)", '/general_meetings/2016-07-10.html' %>
+        </li>
+        <li>
           <%= link_to "December 13 2015 (Rails Camp 18)", "/general_meetings/2015-12-13.html" %>
         </li>
         <li>

--- a/app/views/pages/association.html.erb
+++ b/app/views/pages/association.html.erb
@@ -48,6 +48,9 @@
       <h3>Committee Meeting Minutes</h3>
       <ul>
         <li>
+          <%= link_to "April 19 2016 (Online Webinar)", '/committee_meetings/2016-04-19.html' %>
+        </li>
+        <li>
           <%= link_to "March 15 2016 (Online Webinar)", '/committee_meetings/2016-03-15.html' %>
         </li>
         <li>

--- a/app/views/pages/association.html.erb
+++ b/app/views/pages/association.html.erb
@@ -48,6 +48,9 @@
       <h3>Committee Meeting Minutes</h3>
       <ul>
         <li>
+          <%= link_to "June 21 2016 (Online Webinar)", '/committee_meetings/2016-06-21.html' %>
+        </li>
+        <li>
           <%= link_to "April 19 2016 (Online Webinar)", '/committee_meetings/2016-04-19.html' %>
         </li>
         <li>

--- a/app/views/pages/code-of-conduct.html.md
+++ b/app/views/pages/code-of-conduct.html.md
@@ -6,9 +6,9 @@ In the same way that Matz has written Ruby with a focus on developer happiness, 
 
 Whenever we come together as a community, our shared spaces are opportunities to showcase the best of what we can be. We are there to support our peers - to build each other up, to accept each other for who they are, and to encourage each other to become the people they want to be.
 
-With that in mind, if you are present at any Ruby Australia event, whether as an attendee, organiser, sponsor or speaker, we take it as given that you agree to follow this code of conduct:
+With that in mind, if you are present at any Ruby Australia event, whether as an attendee, organiser, sponsor or speaker, or if you are active in the Ruby Australia Slack, GitHub or Google group, we take it as given that you agree to follow this code of conduct:
 
-The Ruby Australia organisation is dedicated to providing harassment-free experiences at events and conferences for everyone, regardless of gender, sexual orientation, disability, physical appearance, body size, race, religion, or age. We do not tolerate harassment in any form.
+The Ruby Australia organisation is dedicated to providing harassment-free experiences at events and online spaces for everyone, regardless of gender, sexual orientation, disability, physical appearance, body size, race, religion, or age. We do not tolerate harassment in any form.
 
 All communication should be appropriate for a professional audience including people of many different backgrounds. Sexual language and imagery is not appropriate in any circumstance.
 

--- a/app/views/pages/committee_meetings/2016-03-15.html.md
+++ b/app/views/pages/committee_meetings/2016-03-15.html.md
@@ -1,0 +1,131 @@
+# Ruby Australia Committee Meeting Minutes
+
+**15th of March, 2016 - 7:00pm AEDST**
+
+**Held via GoToMeeting**
+
+## Committee Members Present
+
+* Leonard Garvey (President)
+* Melissa Kaulfuss (Vice-President)
+* Jo Cranford (Treasurer)
+* Rebecca Skinner (Secretary)
+* Rob Jacoby
+* Lauren Hennessy
+
+**Apologies**
+
+* Amanda Neumann
+* Angus Scown
+
+## RubyConf AU 2016
+
+* It was good! Everyone had a great time and loved it!
+* Jo has written lots of notes about things she's learned, for next year's organizers to help them out.
+* Rob has not written any notes yet, has been super busy with work
+  * When he gets some time, will write them down and also finish adapting Pat's notes from previous years for general consumption.
+
+## RubyConf AU 2017
+
+* No emails received about wanting to organize next year's conference.
+  * Phil Arndt expressed interest in hosting a conference in Wellington, which may be possible sometime in the future but not next year.
+* Current committee members who are willing and able will get the ball rolling for next year's conf, and then the call can be put out again to get more assistance when necessary.
+  * Len and Jo both put their hands up for this, with Mel in a secondary role.
+* To organize a conference well you need at least one organizer in the local area, and all three volunteers are in Melbourne.
+* Most of the major sponsors will be from Melbourne too, based on sponsorship enquiries so far.
+* A decision has to be made sooner rather than later, so **Melbourne** looks like very likely to host the event.
+  * *Action item!* Mel to tweet about hosting RubyConf AU 2017 in Melbourne, calling again for volunteers to help organize it.
+* Tasmania should be kept on the agenda as a future hosting spot.
+* Given that this is the first year of the sponsorship system, a safe location is better for now.
+* Melbourne it is! Lock it in Eddie!
+
+## Sponsorship prospectus
+
+* REA and Envato have expressed interest in a Ruby sponsorship, as have CultureAmp.
+* Lookahead have also expressed interest, but want to sponsor coffee at All of The Events
+* Rails Girls has been a point of confusion so far
+  * The original plan was that Ruby AU would offer some support with annual sponsorships, but organizers would still be free to seek their own sponsors if they wanted
+  * Venue sponsorship is common with RG events (companies that provide space to host the events), so that may need to come outside an annual sponsorship
+    * RedBubble and REA are both keen to host Melbourne RG events.
+  * Other in-kind sponsorships are common so those combined with the smaller Ruby AU sponsorship packages could work well.
+  * We wouldn't be saying any existing RG teams have to change the way they do things, just offering them other options and potentially a helping hand with money handling and financial support.
+  * Tasmania is starting up a RG event! - Giving them a boost would be great.
+  * Sponsorship is not limited to Melbourne and Adelaide - this was just an initial proposal based on organizers that have been talked to so far.
+  * Most of the RG organizers seem to be on board, even just from a bookkeeping perspective to make their lives easier.
+  * The committee isn't out to dictate who can run events or where, so we should leave the sponsorships open because events are still popping up everywhere.
+* The main focus of the prospectus wasn't Rails Girls (although of course we want to help them out!) - it was larger events like RubyConf, Railscamps, and possibly Melbourne and Sydney RORO.
+* Discussion about the top tier sponsorship...
+  * It was designed that there only be one Ruby sponsor, and this adds an element of prestige
+  * It would be best financially for the community if all three interested parties (REA, Envato, CultureAmp) all agreed to share top billing
+    * The price for the top tier could be slightly lowered to compensate for the prestige factor
+    * We would also have to deal with fewer companies for more money, so less time spent on administrative bookkeeping
+  * (Wouldn't it be funny if we made the companies bid for the top tier sponsorship? Not a serious suggestion)
+  * From a conference perspective, it would mean having three big swag tables
+    * Does this commercialize the conference too much?
+    * It wouldn't be as bad as other events, where they have exhibition halls full of vendors, and barcode scanning on name tags
+    * No slimy sales events!
+    * Guidelines may need to be created about what would be suitable
+    * Try it for one year, see how it goes? Adjust the packages afterwards if it doesn't work out
+  * It would mean more money for the community if all three companies agreed to share a Ruby sponsorship at the top price, instead of one taking Ruby and two downgrading to Emerald.
+    * But exclusivity is worth something in the negotiations...
+  * Propose the companies sharing the sponsorship, and possible price negotiation.
+  * *Update!* CultureAmp has agreed to take an Emerald sponsorship, leaving just Envato and REA duking it out for Ruby.
+
+## New website/membership database
+
+* Yes, we want a new website, but no, we haven't done anything about it yet :(
+* Mel and Amanda were getting together to do some high-level wireframing and planning
+* Open it up to the community to build it?
+  * Feels a lot like spec work though...
+* Hire a designer to do some designs, and then we can build it
+  * Mel will be the product owner, as she is picky about design
+  * Mel also knows a freelancer who can do some design work - will get a quote from them
+* We need a membership database!
+  * The current form on the website may link to Campaign Monitor
+  * Moving away from the current statically-generated site to a proper site with an administration panel etc.
+* Can we please use the rubies for the new website as we're a Ruby community and all that stuff?
+
+## Communication channels
+
+* Announcements on Google groups about events, meetings, etc. are pretty good
+* We could do a better job with managing our Twitter account, like, actually using it for example
+  * Create a Slack channel to share links we could tweet out, and commit to posting regularly
+  * Kind of like at RORO where we ask "what's happened this week?" and someone will shout out "new version of [library]"
+  * Anything Ruby- or community-related is relevant to be shared
+  * Integration with Slack to share all the Ruby AU tweets
+  * Mel is very good at Twitter and using many emojis (and starting a conversation)
+
+## Update on RailsCamp 19 (Radelaide edition)
+
+* 14 tickets sold so far
+  * Sounds bad, but it's pretty good for 4 months away!
+* Ticket cut-off date to be approximately a month away from the event
+  * T-shirts and caterers require about a month
+  * If you let the t-shirt company (eg. PSI) know early they can put the run into their production schedule and save your slot, even if you don't have final numbers yet
+* The Railscamp Twitter account should be delegated to people who are good at this stuff
+* CampaignMonitor can be used to remind people about the camp and where to buy tickets etc.
+* A lot of people are going to go but just haven't bought tickets yet.
+  * Ping people at meetups, remind sponsors to send their people to the camp, etc.
+
+## A very brief Code of Conduct discussion
+
+* Our Code of Conduct should be brought more in line with existing well-regarded codes of conduct eg. Geek Feminism
+* Publishing contact information, and having an internal plan on how to handle problems
+* The current CoC focuses heavily on in-person events, and should be amended to include online spaces such as Slack
+* Lauren has a few issues with the wording in the existing CoC, and will open pull requests to start addressing them
+* A checklist of things to do in case of a report, for event organizers, should be created/sourced
+* We should keep all CoC-related discussions open, transparent and public
+  * Opening pull requests for any issues means that anyone in the community can have a voice
+  * Typos or burning issues can be addressed immediately, but major issues could be discussed at a General Meeting
+* A code of conduct for the Slack community and online spaces can be discussed and created now, as we have the community here to discuss and okay it
+* We really need to keep things focused and moderate discussions - trolls not welcome
+  * Constructive and maybe even contentious is fine, but always polite
+* Having a code of conduct is not up for debate - we already have one and we are keeping it!
+* An integration can be set up for Slack so the committee sees any activity on opened issues, and we can keep on top of things
+
+## Wrap up
+
+* Insert children heads popping on screen, many dogs barking, animated gifs
+* The next committee meeting will be held on Tuesday April 19, at 7:00pm EST.
+
+![](https://assets-cdn.github.com/images/icons/emoji/unicode/1f483.png)

--- a/app/views/pages/committee_meetings/2016-04-19.html.md
+++ b/app/views/pages/committee_meetings/2016-04-19.html.md
@@ -1,0 +1,129 @@
+# Ruby Australia Committee Meeting Minutes
+
+**19th of April, 2016 - 7:00pm AEST**
+
+**Held via GoToMeeting**
+
+## Committee Members Present
+
+* Leonard Garvey (President)
+* Melissa Kaulfuss (Vice-President)
+* Jo Cranford (Treasurer)
+* Rebecca Skinner (Secretary)
+* Rob Jacoby
+* Lauren Hennessy
+
+**Apologies**
+
+* Amanda Neumann
+* Angus Scown
+
+## Actionables from last meeting
+
+* Mel has contacted a freelance designer about redesigning the Ruby Australia website, but does not yet have a concrete spec to give them, of work we want them to do. Was going to sit down with Amanda and flesh one out but has not had the opportunity. Will set that meeting down as an actionable for this month.
+  * Ideas will be shared on Slack also, so it's a real team effort!
+* Use of the Ruby AU-related Twitter accounts has been good!
+  * Kylie has been amazingly awesome in digging up relevant articles to be shared with the community! Big props! &lt;3
+* The call has been put out for more volunteers to help with RubyConf AU, but for now the main goal is to get buzz started, talking about the event.
+
+## Sponsorship prospectus update
+
+* Envato and REA have both put their hand up for a Ruby sponsorship, and were told they could share it for $35,000 each.
+* REA agreed, Envato are still holding out. James (contact at Envato) has been away, so progress has stalled.
+* CultureAmp and Lookahead have both requested Emerald sponsorships.
+* Nothing heard back from reinteractive after the counteroffer made, about a sponsorship mainly consisting of covering InstallFest running costs.
+* Someone to hurry Envato along would be good!
+  * Len is happy for REA to "win" the Ruby sponsorship battle, but it would be better if the community won by having more money available for awesome events, of course!
+* Jo has been doing an amazing job of haranguing people to make sure we get money coming in!
+* reinteractive's sponsorship proposal was a bit of an oddball.
+  * Rebecca to chase up Mikel, restarting the discussion about reinteractive's possible sponsorship of Ruby AU. (Done!)
+  * Everyone appreciates what reinteractive does for the community, but at the same time we need to make sure we have the cash moneys to make events possible. We're not out to make money here, just cover costs!
+* Once the major sponsors are locked in, it would be good to look back and see how things could have been done differently if any, because this is such a new concept for us.
+
+## Railscamp Radelaide Update
+
+* Fine, good! Ticket sales plodding along slowly.
+* Lots of people known to be coming but have not yet bought tickets. Like Len. *gasp*
+  * For a morale boost, prompt these people! People are super lazy and will leave it to the last minute!
+* The activity course - how not-hungover will people have to be to do it?
+  * Wait, is it on Saturday or Sunday morning? (Saturday morning!)
+  * The website said Sunday morning! To be fixed!
+* The domain name for the website needs to be fixed - Len to help Lauren with that.
+  * railscamp.ruby.org.au to be the domain going forward.
+
+## RubyConf AU 2017 update
+
+* A group has formed, of people willing to take on this momentous challenge.
+* The group is meeting next week for dinner, to start throwing around ideas and making plans.
+* Deb, the event planner from the last Melbourne conference, has been enlisted again.
+  * At the moment she is looking at venues and their costs.
+* Conference may be slightly larger, and be dual-track for one of the days.
+* Lots of this discussion is taking place in a Slack channel, which anyone in the committee is welcome to listen in on. (Not for public access, sorry!)
+* Date looks like being sometime in February, again.
+  * Moomba, Labour Day and the Grand Prix are all in March in Victoria, so March is probably not going to work.
+* Catering is surprisingly expensive in Melbourne!
+* Definitely need to make the conference accessible - to university students, to people new to the community, to people who may not be working and might not have the money for a full-priced ticket.
+  * The number of RubyConf Assist and concession tickets has been increased, in the budget
+  * This is all still up in the air at the moment, to be discussed by the conference group when they meet next week.
+* Rob will be looking after the website for the next conference.
+  * Looking at the possibility of having a design sponsorship for the conference - offering an Opal sponsorship in return for design and build of the conference website, posters, T-shirt, lanyards, etc.
+  * Can see if there is some leftover design time for camps as well.
+  * Reminder that US conferences operate on an entirely different scale to our little conference - 1600-1700 people attending over there!
+  * The group will put it out for tender if they decide to go ahead with the design sponsorship idea.
+
+## New website and membership database!
+
+* Ed has already rebuilt the existing website in Rails.
+* We have a beta.ruby.org.au domain name set up that we can use for the new site
+  * If Ed can deploy the new site to Heroku, then we can point the beta CNAME at it.
+  * Len to sit down and figure that domain name stuff out too!
+
+## Possibility to hold AGMs online?
+
+* It was a thing that was discussed at the last AGM, so are we going to try to do it?
+* Nominations before the camp are definitely a great idea.
+  * Ruby NZ had nominations open until 1pm on the Saturday, then the AGM on the Sunday
+  * Saves time in the AGM, and also you don't have to attend camp to be nominated.
+  * Also gives people time to think about who to nominate, vote for, etc.
+  * Nominees have time to discuss the responsibilities, etc. with existing members
+  * A couple of weeks before the camp, we can open up nominations via Slack, Google group, etc. Detail the roles, outgoing members, etc.
+  * How will we accept nominations? To be brainstormed and decided at the next meeting.
+  * Do we need to have a second for nominations?
+* Holding an AGM online may not be feasible yet, but publishing an agenda before the AGM to prompt people to start thinking about things to discuss in the meeting definitely would be.
+  * 'A-ha' moments and people discussing whatever pops into their heads is valuable, but giving people time to think about it beforehand is also good.
+* Rebecca is a bit unsure about how AGMs are typically organized and run (and that would be her duty to do, so here come the knowledge bombs)
+  * They typically have a more set structure than these informal committee meetings
+  * Ratification of the last minutes, reports from various committee members such as treasury, then voting in of new committee members
+  * Pat Allan has run them successfully in the past, also having been secretary before
+  * Usually a lot of stuff that gets talked about afterwards that is not on the agenda - these are what people should be thinking about beforehand
+  * We want to avoid the "3 hours of discussion" part, but still give anyone who wants to turn up the opportunity to ask any burning questions on their mind
+  * A couple of weeks before Railscamp, Rebecca will open up a new thread on the Google group detailing the AGM, asking for nominations, etc. Have a living agenda. Prompt people to think of things they might want to ask, which will probably start some discussion.
+
+## Railscamp 20?
+
+* It keeps getting brought up that we would love to have it in Tasmania.
+* If we were to select people to run RC20, at RC19, then the timeframe would be too tight (5 months).
+* It would be best to hold it in late November or very early December, to avoid being close to Christmas.
+* Tasmania would definitely be best for a summer camp - far too cold in winter for those used to warmer climes.
+* Other option is Melbourne, but the conference is also there in early 2017, so let's spread the love a little.
+* Everyone loves the idea of Tasmania, so next step is to identify some willing Tasmanians to run it!
+* No real hurry, but we know of some to reach out to.
+
+## Moving away from the Railscamp brand?
+
+* Has been brought up as a possible idea, because people get the wrong idea and think it's only about Rails dev.
+* Any change could also be exclusionary - if you change it to a general 'web dev' camp, you exclude people who may write Ruby but aren't involved in web dev.
+* Maybe just let it be what it is - it seems to be working alright so far.
+* No-one actually programs in Ruby at Railscamp anyway... do they?
+  * CampJS is a thing, as is ElixirCamp later this year.
+
+## Actionables for next month
+
+* Mel and Amanda to meet and put together initial ideas of what should be on the new Ruby AU website.
+* Envato to be chased up again about sponsorship.
+* Rebecca to chase up Mikel about reinteractive's sponsorship
+* Len to assist Lauren with setting up a proper domain name for the Railscamp website, that can be updated for each new camp.
+* Len to talk with Ed about getting the new Ruby AU website running on Heroku under the beta.ruby.org.au URL.
+* Rebecca to start sending out reminders 2 weeks out, 1 week out, etc. for committee members so they don't forget the meetings are on!
+
+_This writeup brought to you by the letters R and C, and Rebecca's cat Scooter who appears about eight times on the meeting recording saying hello. :3_

--- a/app/views/pages/committee_meetings/2016-06-21.html.md
+++ b/app/views/pages/committee_meetings/2016-06-21.html.md
@@ -1,0 +1,83 @@
+# Ruby Australia Committee Meeting Minutes
+
+**21st of June, 2016 - 7:00pm AEST**
+
+**Held via GoToMeeting**
+
+## Committee Members Present
+
+* Melissa Kaulfuss (Vice-President)
+* Rebecca Skinner (Secretary)
+* Rob Jacoby
+* Lauren Hennessy
+
+**Apologies**
+
+* Leonard Garvey (President)
+* Jo Cranford (Treasurer)
+* Amanda Neumann
+* Angus Scown
+
+## Committee nominations
+
+* Three positions will be up for nomination at Railscamp 19 - vice president and two general members.
+  * Update: Also now, secretary.
+* We now have a copy of the original committee constitution, and a New Committee Member Welcome Guide!
+* As a group, unsure what is happening with Angus' committee membership at the moment.
+  * Proposal to draft a reply email for Len to send back to Angus - Lauren to handle
+* A post should be written for the mailing list, to announce open nominations
+  * This could be in the form of an email to the secretary or some nominated address, with the name of the person being nominated and 25 words or less about why they are being nominated
+  * Precedent is there for nominations pre-camp - Jo nominated herself before the last RC.
+* The actual process isn't super important - the important part is letting people know what positions are available, giving them time to think about what they want to say before the camp, and also speeding up the nomination process during the meeting itself (as it can take some time).
+* Parts of the New Committee Member Welcome Guide can be used in the initial post, to let people know a bit about what they're signing up for.
+* A Google form would be easy to set up to collect nominations.
+  * Rob will set one up - too easy!
+
+## Railscamp update
+
+* Possible controversy incoming - not as much alcohol to be provided!
+* Budget is not as healthy as expected - some smaller sponsorships fell through
+* Alcohol is expensive!
+  * Can be a very large and also quite unpredictable cost.
+  * Almost every camp in recent memory has had large $1000+ alcohol top-ups mid-camp
+  * Safety and liability issues can crop up when supplying endless amounts of booze
+  * Will be able to make mulled wine, cider, hot chocolate, spiced rum, etc. in the kitchens at night
+  * Wine tasting during the day on Sunday
+  * The buses to the camp will stop at a Dan Murphy's so campers can stock up on their own alcohol
+  * CampJS has tried not supplying alcohol, just providing a method of keeping alcohol cold
+  * Can backfire, as people will tend to bring spirits to avoid lugging around beer
+  * Apparently Aldi beer is bad! Who knew!
+* 113 registered attendees for the camp! Awesome! :D
+
+## RubyConf update
+
+* Venue for RubyConf AU 2017 will be Melbourne Convention & Entertainment Center (MCEC)
+* Dates will be 9th-10th February 2017
+* Splash page being finalized
+* Super-early-bird tickets will be put on sale during Railscamp
+* Nothing locked in yet for social events
+  * Closing party won't revolve around alcohol!
+  * Looking more for activities instead of standing around drinking
+
+## Rails Girls funding
+
+* BrisRuby is having trouble getting sponsors for Rails Girls
+* Original plan many moons ago was a blanket sponsorship amount, $20 per attendee, but that was before the sponsorship prospectus was set up
+* Sponsorship prospectus changed it to be Mel/Syd only, because that's where all the sponsorship money comes from
+* The big problem is that the information about sponsorships is not being broadcast; Rachelle and Sorcha didn't even know it was available
+* Sponsorships were set up to cover the big things, but also help out with the smaller events where its harder to find sponsors
+* Budget for RubyConf is looking healthy (assuming good ticket sales) so there should be money to cover events like RG
+* We would like to be able to offer that $20pp from Ruby AU to any Rails Girls event that asks for it
+* There's a Slack community that most of the RG organizers are in; we can let them know that the sponsorship is available
+* We're all in agreement we would like to do it, but Jo has to give the final nod as she is our esteemed Treasurer
+  * Update: she said yes to RG Brisbane! 💖
+
+## Rob says his goodbyes!
+
+* He's looking forward to having a rest after two years on the committee, and *just* organising confs (because that is apparently much easier)
+* He's had much fun and wishes us luck with everything to come :)
+* Mel isn't saying her goodbyes now - she'll see us all at Railscamp in Adelaide
+* Rob had to get his farewells on the record and yes they are indeed now in the minutes!
+* Thank you for your service Rob, you've been a most excellent committee member, an awesome conf organizer, and we all look forward to seeing you at future events!
+
+ps. technical glitches and strange muted microphones are fun!

--- a/app/views/pages/general_meetings/2016-07-10.html.md
+++ b/app/views/pages/general_meetings/2016-07-10.html.md
@@ -1,0 +1,303 @@
+# Ruby Australia Annual General Meeting Minutes
+
+**10th of July, 2016 - 3pm**
+
+**Held at Rails Camp 19 - Mylor Adventure Camp, Adelaide**
+
+## Committee Members Present
+
+* Len Garvey - President
+* Melissa Kaulfuss - Vice President
+* Jo Cranford - Treasurer
+* Rebecca Skinner - Secretary
+* Rob Jacoby - General Member
+* Lauren Hennessy - General Member
+
+## Apologies
+
+* Amanda Neumann - General Member
+* Angus Scown - General Member
+
+## Ruby Australia Members Present
+
+* Adam Davies
+* Alexia McDonald
+* Andrè Vidic
+* Andrew Harvey
+* Anton Katunin
+* Candy Goodison
+* David Trumbull
+* Edward Tippett
+* Eleanor Kiefel Haggerty
+* Felescia Schemmer
+* Garrow Bedrossian
+* Grant Colegate
+* James Martelletti
+* James Sadler
+* Joseph Mullins
+* Keira Hodgkison
+* Keith Pitt
+* Kevin Yank
+* Kieran Andrews
+* Kylie Gusset
+* Liam Esler
+* Luke Rollans
+* Luke Shillabeer
+* Maria Cano
+* Mel Sherrin
+* Mitchell Buckley
+* Murray-Luke Peard
+* Nigel Rausch
+* Nigel Soon
+* Pat Allan (MC)
+* Paul Fioravanti
+* Paul Millar
+* Richie Khoo
+* Sebastian von Conrad
+* Simon Rentcke
+* Steve Gilles
+* Steven Noble
+* Toby Nieboer
+* Yuji Yokoo
+
+(If you attended but are not listed, or your name is misspelled, please contact your local Committee secretary)
+
+## Introduction
+* Meeting being run by Pat Allan, with Rebecca Skinner taking minutes.
+* Welcome to Country - traditional lands of the Peramangk and Kaurna people
+* Apologies - committee members Amanda Newmann and Angus Scown
+
+## Purpose of Ruby Australia
+* Further use and adoption of Ruby in Australia
+* Foster community around the language and related technologies
+
+## Motion to accept minutes
+* Motion made by Pat, seconded by Len
+* Motion passed without dissent.
+
+## Presidents Report - Len Garvey
+* Committee has been focused on two things
+  * Corporate sponsorship - making events easier
+  * Association membership - understanding who we are
+* Constitutional effects like: 5% of members can call a SGM and members needing to rejoin annually
+* Not focusing on the three areas (Community outreach, business outreach, and event organisation) from one year ago
+* Survey was run and turned up some interesting statistics
+  * See [full survey results](/files/survey-results/2015-ruby-au-survey.pdf)
+
+## Treasurer's Report - Jo Cranford
+* 200K currently in bank
+* Events to be covered are RubyConf, camps, RORO Melb/Syd + a bit of Adelaide, Rails Girls in Melb/Adel + a bit of Brisbane
+* 200K includes sponsorship for next year’s conference
+* Slight loss on last conference - between 10-20K
+* Financial report to be published
+* Possibility of membership fees to increase revenue?
+* Costs vary between events - most of the cost is covered by tickets but some can come from Ruby AU
+* Camps should run at even money or a slight loss, confs should run at a profit to subsidise them
+* (Richie) Why did the last conf lose money?
+  * Ticket sales were lower, costs were higher
+  * Costs were done based on ticket sales from Melbourne - were not as high. 100 ticket sales less
+  * A lot of no-shows for the conference
+
+## Sponsorship - Jo Cranford
+* Sponsorship model used to be per-event - confs and camps trying to organise their own money
+* Stressful for conf organisers and things like Rails Girls had no chance
+* Easier for organisers and companies to only ask once and get the money at the start of the year
+* Single top tier Ruby sponsor, some Emerald + Sapphire, etc.
+* REA and Envato sharing the Ruby sponsorship
+* Two Emerald sponsors - CultureAmp and Lookahead
+* 120K from those four in the bank (yay)
+* Looking for 5 Sapphire sponsors
+  * (Len) We do have a prospectus so people can share it with their companies or promote it themselves. [Download it here.](/files/annual_sponsorship.pdf)
+* (Liam) is there a committee member responsible for sponsorship stuff? As it can be a big load
+  * At the moment it is just Jo, with help from other people in the committee
+* Does need someone who can devote a lot of time to it.
+* Possibility of assigning particular responsibilities to specific general members.
+
+## RubyConf 2016 Report - Rob Jacoby
+* Held on the Gold Coast in February 2016
+* 370ish attendees
+* 20min/30min talks worked well
+* Closing party was *awesome*
+* Catering and social events for 350 people is not easy!
+* Ticketing of social events didn’t really work as a lot of people were no-shows and others got turned away as a result
+* Jo and Rob also working for next year’s conf so knowledge learned will roll over
+* Mel, Len and Nicholas also helping for next year.
+* Anonymous CFP went well, as did RubyConf Assist
+* (Andrew) International speakers seemed to really engage with the conference and events
+  * Some international speakers said it was the best conf they had ever attended, and they say it loud
+  * We do offer travel allowance for international speakers.
+* (Richie) Backup speakers from overseas - a bit weird? Coming all that way and not getting to speak? A good use of financial resources?
+  * Talks were selected based on CFP only - top ranked talks were accepted, next top were selected as backup.
+  * Backups were selected without regard to where speakers were from.
+  * Something to maybe improve on for next year.
+* (Kylie) Do we need to look more outside the community for international speakers for softer talks?
+  * Would cost about the same. - Liam
+
+## RubyConf 2017 - Mel Kaulfuss
+* Grand announcement is later tonight so no information!
+* Venue and dates are locked in.
+* Working hard to find a conf direction, maybe a theme, like the Future of Ruby
+* (Len) It’s in Melbourne!
+    * (Mel) Can we say that yet????
+* Hoping to keep the costs down - maybe not as baller as Gold Coast conf
+* Focus on student and diversity tickets
+* We could hold a Gold Coast conference because previous confs had gone so well and made a profit, so that may become a regular thing - every other conference being held in a non-Sydney/Melbourne location
+* Short talk format has been good and quality has been very high - though not as much depth in shorter talks
+* More details soon!
+
+## RailsCamp 19 - Lauren Hennessy
+* The camp has been awesome!
+* Budget is healthy - made that ‘only a little loss’ goal
+* Happy with the diversity - tickets, etc.
+* 112 attendees!
+* Big thanks to LK and the volunteer team!
+
+## RailsCamp 20!
+* Open for expressions of interest
+* Never had one in NT...
+  * Next on the list of least-recently visited locations are Tasmania, Melbourne, and Queensland
+* Lauren has been writing lots of notes and guides to help future organisers run camps, and she (and other organisers) can help and nurture you if you are interested in helping!
+* Winter in Cairns/NT for RailsCamp 21??
+  * Would work well weather-wise, if Tas was done in summer this year.
+* (Kylie) Is 5 months logistically possible? Can we skip one?
+  * Sponsorship agreements say we are holding 2 a year
+  * Have been 2 a year since 2007
+* Do organisers have to be located where the camp is actually being held?
+  * It has happened somewhat before
+  * Some local knowledge is good
+  * The documentation is going to get knuckled down and done so it will be made easier for future organisers!
+  * Site visit *has* to be done, but that’s really the only requirement for being in the location
+  * Site visit doesn’t have to be done by you but does have to be someone you trust
+  * Do have to be in the location couple days before/after for organisation purposes
+
+## General member discussion - Len Garvey
+* One committee member has not been participating - Angus
+* Provision in the constitution for ending a term early
+* Replacement member would fulfil the rest of the term (6 months)
+* Rob reads out Angus’s email
+* We can change the constitution at the end of the meeting - Len thinks the replacement member should serve the full term
+  * Mel Sherrin going to review the constitution from a lawyer perspective and see if it can be done. (Right now)
+* Proposal by Len to vacate Angus’s committee position
+* (Garrow) Should we just assign someone else to his role?
+    * Well it would normally be done as part of general business, but that’s after the election and we’re having an election today so would like to get it cleared up now.
+* (Richie) Against the motion. The committee turnover should be stabilised at 4-4 instead of 5-3.
+* (Mel S) - Clarification - changing the constitution requires a special motion that can only be done with advanced notice. No changing without 21 days notice. Also need to update constitution as we are running off an old act.
+* Original proposal at replacing Angus for a 6 month term made by Len, stands.
+  * Seconded by Mel K.
+* (Sebastian) Unusual, unprecedented to replace a committee member “against their will”. However, the fact that the committee have the most information and given it was raised/seconded by president/vice president makes him more comfortable with it.
+* (Mel S) \*reads over some more of the legalese that includes provision for when a member misses 3 continuous committee meetings without any advanced notice\*
+* (Richie) Let’s put it to a vote.
+  * Everyone will vote/abstain, Pat and Mel S will count votes.
+  * Lauren has a preference for an anonymous vote, but that was done last time because people being voted on were in the room. No harm in anonymous anyway.
+  * (There will be no patting of legs during this night phase, ala werewolf)
+  * Motion has passed. 25 for, 2 against, 13 abstain.
+
+## Committee election time!
+* Positions up for election are:
+  * Vice President (held by Mel K)
+  * Secretary (held by Rebecca)
+  * 2 full term general members (held by Rob and Amanda)
+  * 1 half-term general member (held by Angus).
+* Even though Rebecca is stepping down halfway, her replacement is full term because it is voluntary.
+  * (Being verified by Mel S).  
+* Discussion of VP role
+  * Support role for president
+  * In absence of president, VP would step in and act as president
+  * Shepherding of issues and ideas into action
+  * Not standing for re-election because she is not committing enough time (she feels)
+  * 1-2 hours/week for general member + time for monthly meetings
+* Lauren Hennessy nominated by Jo, seconded by Mel K
+  * Would her current General Member role be replaced for remaining-term or full-term?
+  * Full-term precedent set by Len.
+  * Other members who have been 'upgraded' have only had their replacements for the remaining term.
+  * It will only be the remaining term.
+* No other nomination.
+* **Lauren Hennessy elected unopposed as Vice President for a 12 month term.**
+
+* Discussion of secretary role
+  * Organizing of agenda for monthly meetings
+  * Running of monthly meetings, typing up minutes, herding cats
+  * Some future corporate-facing work may be required.
+  * Does require decent organisational skills.
+  * Couple hours of month required, more if you're a stress-head like Rebecca.
+* Ryan Bigg (not present) nominated as secretary, seconded by Michael Pearson.
+  It was discussed with him beforehand and he accepted the nomination.
+* Kylie Gusset nominated by Lauren
+  * Kylie declines, saying she would prefer to be nominated as a general member instead.
+* Mel Sherrin nominated by Lauren, but she shakes her head vehemently.
+* No other accepted nominations
+* **Ryan Bigg elected unopposed for a 12 month term.**
+
+* Discussion of General Member responsibilities
+  * Attend meetings once a month
+  * Discussions about furthering community.
+  * 1-2 hours a week maybe.
+* Kylie nominated by Lauren as general member
+  * Seconded by Len, nomination accepted
+* Tom Ridge (not present, Brisbane) nominated by Rob Jacoby.
+  * Seconded by Nigel.
+  * Also discussed beforehand and accepted.
+* Andrè nominated by Jo, seconded by Liam, accepted.
+* Ed nominates himself for the 6 month term only. Seconded by Rob.
+* Adam nominated by Lauren - not this time, he says.
+* Anton nominated by Simon, seconded by Nigel, accepted.
+* Discussion on how to split the nominations for the 6/12 month roles. 2 for 12 month roles, 2 for 6 month roles.
+* Introducing 12 month nomination people.
+  * Anton - Melbourne, contractor, doing Ruby for 5 years, was in Brisbane, hosted meet ups, haven’t taken any big roles so wants to move into helping more.
+  * Kylie - Melbourne, Rails Girls SOC supported by CultureAmp and working with Katrina Owen. Involved with community for 6 months. Also involved in CSS/JS Conf. Involved in diversity efforts and handling Twitter account for Railscamp. (⛺⛺⛺⛺⛺⛺)
+  * Andrè - Melbourne. In community for year and a half. Put hand up last year when there were heaps of nominations. Will give it a go again! Relative newcomer to community, welcomed awesomely, pretty passionate about it and getting new people and youngsters involved. Went to General Assembly to kickstart learning process. Giving talks to new students there to give back. Random Acts of Kindness but wants to concentrate on Ruby.
+  * Tom - Brisbane, 2 Red Kites. Speaks at lots of BrisRuby meet ups, always has interesting things to say and passionate about mentoring. Loves the community. Would be a good asset. (Spoken by Rob)
+* Everyone can vote twice between the 4 applicants for the 12 month positions. (Another anonymous vote is held)
+* Congrats to **Kylie and Tom** 🎉 for being elected as 12-month general members.
+* Introducing 6 month nomination people
+  * Ed - Adelaide, 5 years in Ruby community, wants to put together a membership database for the Ruby community.
+  * All non-successful nominations for the 12 month positions also apply for the 6 month positions.
+* Congrats to **Andrè and Ed** for being elected as 6-month general members.
+* The new and improved Ruby AU committee is:
+  * President: Len Garvey
+  * VP: Lauren Hennessy
+  * Secretary: Ryan Bigg
+  * Treasurer: Jo Cranford
+  * General members: Kylie Gusset, Tom Ridge, Ed Tippet, Andrè Vidic
+
+## General business
+* (Richie) Scott Ludlam’s closing conf talk. We are members of a digital class and highly privileged. Extreme amounts of information. Let’s not close the internet. So. What can we do? Be more digitally active to ensure a “free and open internet”. EFF in the US, EFA here. As the internet grows, grey areas of rights as companies and countries inhibit rights. Don’t track all of the things. Bad policies suck. Should we support the EFA locally? Digital rights non-profit? Financially, or as a community. Companies find it hard to contribute because it makes them a target - as an organisation we may be able to give back instead.
+  * Suggestion from Pat - before the next Rails Camp, Richie to work with the committee and other interested people to put together a proper proposal about what we can do and how, to discuss at next Rails Camp.
+  * (Len) how does that further the mission of Ruby AU? Let’s make it clear before we make any action.
+  * Mel S to help with the conversation.
+  * Need a lot of due diligence to make sure the beliefs of the organisations align.
+    * Our sponsors also might have issues with Ruby AU formally sponsoring these organisations.
+  * Discussions to be had and see what can be done by next RC.
+* (Pat) Phil works with Ruby Together and would like to discuss the possibility of Ruby AU putting some kind of help and support towards Ruby Together.
+  * More ideas to investigate and see what can be done.
+  * (Alexia) When people register and pay membership fees, maybe can check a box to contribute extra fees towards worthy causes like Ruby Together.
+  * (Len) The committee can take these issues into advisement and put together a proposal moving forward.
+  * (Rebecca) Wanted to raise that Ruby Together does have very strong social beliefs that some people specifically might not be comfortable in supporting.
+* (Liam) Updates from AGM to AGM, subcommittees, etc. We don’t really have any!
+  * Was covered very briefly in the President’s report.
+  * (Garrow) Wanted an update on the member registry.
+  * (Kylie) Wanted an update on hiring an admin, which was brought up at last RC.
+    * Not really enough work for that. Some specific work can be assigned to committee members so things don't fall off the radar.
+  * A lot of people don’t read the minutes, so maybe just a status report before the meeting starts, to get everyone up to speed.
+* (Nigel) - An update on getting speakers to struggling meet up groups like Adelaide, Perth, etc.
+* (Sebastian) - Perplexed about sponsorships and how we don’t have funds?
+    * 1 year ago, treasury had 100K sitting in the bank not allocated for events, pure profit.
+    * Was the report back then incorrect or are we running at a big loss now?
+    * (Len) Matt was towards the end of the term and familiar with ebbs and flows of the cash. Jo still fairly new to role.
+    * Now covering more RORO events so more expenditure.
+    * Sebastian proposes that some kind of investigation should be done to see what has/is happening.
+    * Len happy to accept proposal and take that action. Report to be posted to ruby.org.au.
+    * (Richie) Financial statements to be provided at AGMs. Profit/loss, not just cash in bank. Cash flow statement. Balance sheet. etc.
+    * Element of conversatism.
+    * Things being asked for are completely reasonable and will be done. :D
+    * There were a lot of expenses for RubyConf that had not been paid when Jo took over, and also a lot of unpaid invoices that caused a bit of a cash flow problem (thanks for the clarification Jo!)
+* (Sebastian) RE: Angus. Committee should formalise description and expectation of all committee members. Has been very informal to this point.
+    * Seconded by Rob. No dissenting voices. Motion passed.
+    * (Liam) Committee also needs to really understand the constitution. Lucky we had a lawyer present this time. Don’t want to get audited.
+    * Mel S volunteers to help new secretary with understanding the constitution.
+* (Richie) Thanks to everyone involved in the committee.
+* (Lauren) Subcommittee for Railscamp budgeting and Railscamp website. Happy to help drive that.
+* (Richie) New Committee Member Welcome Guide - very out of date. Should be updated and passed on to new committee members.
+  * To be part of the new secretary role.
+* More minor chit-chat and wrap-up.
+* Meeting adjourned! Until next time, friends!

--- a/app/views/pages/meetups/syd.html.erb
+++ b/app/views/pages/meetups/syd.html.erb
@@ -9,7 +9,7 @@
     </h4>
 
     <h4>
-      6:30 (for 7pm) at the <%= link_to 'King St Brewhouse', 'http://kingstbrewhouse.com.au/contact/' %> at King St Wharf on Darling Harbour, Sydney.
+      6:30 (for 7pm) at the <%= link_to 'Pivotal offices', 'http://pivotal.io/locations/sydney' %> at 155 Clarence St, Sydney.
     </h4>
 
     <p>

--- a/app/views/pages/rails-girls.html.erb
+++ b/app/views/pages/rails-girls.html.erb
@@ -1,0 +1,21 @@
+<h1>Rails Girls</h1>
+
+<p>
+  Join the Rails Girls Melbourne mailing list here.
+</p>
+
+<%= form_tag "http://rubyaustralia.createsend.com/t/j/s/qtheu/", id: "subForm" do %>
+  <p>
+    <%= label_tag "cm-name", "Name" %>
+    <br>
+    <%= text_field_tag "cm-name" %>
+  </p>
+
+  <p>
+    <%= label_tag "cm-qtheu-qtheu", "Email" %>
+    <br>
+    <%= text_field_tag "cm-qtheu-qtheu" %>
+  </p>
+
+  <%= submit_tag "Subscribe" %>
+<% end %>


### PR DESCRIPTION
Merging changes since Feb from rubyaustralia/ruby.org.au to rubyaustralia/ruby_au with the intention of making ruby_au _the_ app on ruby.org.au.