### PR TITLE
Update articles page to add committee elections

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -40,6 +40,19 @@ a {
 /* Header levels */
 h1 {
   line-height: 1;
+
+  a {
+    $link-color: #333333;
+    color: $link-color;
+    text-decoration: none;
+    border-bottom: none;
+    &:hover {
+      color: lighten($link-color, 15%);
+    }
+    &:active {
+      color: lighten($link-color, 25%);
+    }
+  }
 }
 
 h2, .h2 {

--- a/app/views/pages/articles.html.erb
+++ b/app/views/pages/articles.html.erb
@@ -1,0 +1,9 @@
+<%# Skipping Rails conventions on render to allow linking to individual pages %>
+
+<section>
+  <%= render file: 'pages/articles/2016-11-21-ruby-au-elections' %>
+</section>
+
+<section>
+  <%= render file: 'pages/articles/2014-02-26-gender-equality' %>
+</section>

--- a/app/views/pages/articles/2014-02-26-gender-equality.html.md
+++ b/app/views/pages/articles/2014-02-26-gender-equality.html.md
@@ -1,4 +1,5 @@
-# On Gender Equality in the Australian Ruby Community
+# <%= link_to 'On Gender Equality in the Australian Ruby Community',
+'articles/2014-02-26-gender-equality' %>
 
 
 Written by [Elle Meredith](https://twitter.com/aemeredith), one of the RubyConfAU 2014 organisers and a Ruby Australia committee member. It was reviewed by the other conference organisers and committee members before publication.

--- a/app/views/pages/articles/2016-11-21-ruby-au-elections.html.md
+++ b/app/views/pages/articles/2016-11-21-ruby-au-elections.html.md
@@ -1,0 +1,111 @@
+# <%= link_to 'Ruby Australia Committee Elections',
+'articles/2016-11-21-ruby-au-elections' %>
+
+
+We have 5 open positions which include the President and Secretary roles, plus
+two full-term and one half-term general position.
+Below is a brief description of each position,
+as well as some general information on the workings of the committee and the
+current direction and focus.
+
+We also have a [nomination][nominations] form to help streamline the meeting.
+
+Each committee member is expected to attend a monthly 1 hour online meeting
+(scheduled around all members other commitments),
+and to have regular access to Slack, 1password and Google docs.
+These are minimal requirements for staying in contact with the rest of the
+committee and accessing required files and login information.
+The time outputs outlined below are loose,
+with more time often needed at crucial points throughout the year and less at
+other times.
+
+Critical points are usually:
+- Turnover of committee members (after each Rails Camp)
+- Weeks before RubyConf and Rails Camps
+- Turnover of the financial year
+
+
+## Open positions
+### President
+The President guides the overall direction of the organisation.
+They make the final call on major decisions and delegate work to General Members.
+They are in charge of making sure the committee is running smoothly and
+committee members are meeting their obligations.
+
+Occasionally they need to mediate interpersonal issues within the committee or
+address Code of Conduct breaches within the member base.
+
+The President is in charge of chairing the online meetings,
+though this is often delegated to the Secretary.
+They also cast the deciding vote in the instance of a draw.
+
+Time output: 5+ hours a week
+
+
+### Secretary
+The Secretary is responsible to ensure that formal legal and governance
+requirements of running an association are maintained.
+They also handle the nitty-gritty of day-to-day committee operation,
+such as keeping members in the loop on meetings,
+taking and distributing minutes and maintaining our online accounts.
+We also expect that they will be in charge of maintaining a new member database
+in the coming year.
+
+The Secretary job is a big one, which can involve delegating work out to General
+Members.
+
+Time output: 4-5 hours a week
+
+Our existing Secretary, Ryan Bigg, intends to run for reelection.
+
+### General Members
+General Members are tasked with supporting the current needs of the organisation
+in various ways.
+They might be on the organising team of an upcoming camp or conference,
+heading a subcommittee to work on a particular aspect of the organisation like
+the website/sponsorship or handling the social media and other member
+communication.
+We try to utilise the strengths and interests of each member to their best
+effect,
+and to allow them a fair amount of autonomy in their area of focus.
+
+Time output: 2-3 hours a week
+
+
+## Goals for 2017
+The main goals of the organisation for 2017 are:
+
+- Streamline onboarding of new committee members
+- Refine the yearly sponsorship model
+- Gain greater knowledge of our membership base and communicate better with
+members
+- Continue to streamline the organising and running of major events though guides
+and support from previous organisers
+- Refine our Code of Conduct to be clearer and instate internal protocol for
+handling complaints and breaches
+
+Particular skills we would love to add to the team are:
+
+- Sponsorship: the ability to secure sponsorships and maintain contact with
+sponsors to ensure good relationships are in place
+- Membership: a working knowledge of community membership bases, record keeping
+and communication
+- Code of Conduct: experience with instating or amending Code of Conduct
+documents and/or enforcing them, particularly within community groups.
+- Social media: skills in social media engagement, blog writing, mailouts, or
+other forms of external communication.
+
+We welcome anyone who is interested in joining the team to step forward,
+but if you have skills or passion for any of the goals outline above then we will
+be especially lucky to have you.
+
+As it's common for existing members to move into open positions,
+we encourage nominees to consider which positions they would be interested
+in accepting before the meeting.
+If you want any more information about the
+committee, please feel free to [contact] us.
+Otherwise, get [nominating][nominations]!
+
+[nominations]: https://docs.google.com/forms/d/e/1FAIpQLSdK7a3N3-5XT5LRqZIVBqEW1NgcxNTZJqaVs7kHwgwyZ1wDog/viewform 'Nominations'
+[contact]:
+mailto:railscamp@ruby.org.au 'contact'


### PR DESCRIPTION
- redo articles page to show more than one article.
- add dates to article links.
- prepare articles for more dynamic generation and display.