### PR TITLE
archive old nominations article

### DIFF
--- a/app/views/pages/articles.html.erb
+++ b/app/views/pages/articles.html.erb
@@ -5,9 +5,5 @@
 </section>
 
 <section>
-  <%= render file: 'pages/articles/2016-11-21-ruby-au-elections' %>
-</section>
-
-<section>
   <%= render file: 'pages/articles/2014-02-26-gender-equality' %>
 </section>


### PR DESCRIPTION
* as @tcn33 rightly pointed out, this was confusing.
* Appending the date to the titles didn't look very appealing either.
* archive the old article by removing it from the articles page.

relates to comments left in https://github.com/rubyaustralia/ruby_au/pull/27