### PR TITLE
Update community menu links

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -80,28 +80,19 @@
         <h3>Community</h3>
         <ul>
           <li>
+            <%= link_to 'Forum (Ruby Down Under)', "https://forum.ruby.org.au", target: :blank %>
+          </li>
+          <li>
+            <%= link_to 'Chat (Slack)', "https://ruby-au-join.herokuapp.com/", target: :blank %>
+          </li>
+          <li>
+            <%= link_to 'Videos', "https://www.youtube.com/channel/UCr38SHAvOKMDyX3-8lhvJHA", target: :blank %>
+          </li>
+          <li>
+            <%= link_to 'Mailing list', "https://groups.google.com/forum/#!forum/rails-oceania", target: :blank %>
+          </li>
+          <li>
             <%= link_to 'Articles', "/articles" %>
-          </li>
-          <li>
-            <%= link_to 'Mailing list', "https://groups.google.com/forum/#!forum/rails-oceania" %>
-          </li>
-          <li>
-            <%= link_to 'Forum (Ruby Down Under)', "https://forum.ruby.org.au" %>
-          </li>
-          <li>
-            <%= link_to 'Slack', "https://ruby-au-join.herokuapp.com/" %>
-          </li>
-          <li>
-            <%= link_to 'IRC (#roro)', "http://kiwiirc.com/client/irc.freenode.net/roro" %>
-          </li>
-          <li>
-            <%= link_to 'Videos', "https://vimeo.com/rubyau/channels" %>
-          </li>
-          <li>
-            <%= link_to 'Mentoring', "https://github.com/rails-oceania/roro/wiki/Mentoring" %>
-          </li>
-          <li>
-            <%= link_to 'Wiki', "https://github.com/rails-oceania/roro/wiki" %>
           </li>
         </ul>
 


### PR DESCRIPTION
As discussed on the previous committee meeting to remove old links. 
Also prioritised official resources and changed videos to Youtube

before 
![image](https://cloud.githubusercontent.com/assets/831942/25130001/ddbfce80-2483-11e7-8138-9a9943dabff7.png)

after 
![image](https://cloud.githubusercontent.com/assets/831942/25130008/e6b25b0c-2483-11e7-94b0-f1784b19f4e1.png)
