### PR TITLE
ensure contact email points at contact@ruby.org.au

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -94,7 +94,7 @@
             <%= link_to 'Twitter', "http://twitter.com/rubyaustralia" %>
           </li>
           <li>
-            <%= link_to 'Email', "mailto:info@ruby.org.au" %>
+            <%= link_to 'Email', "mailto:contact@ruby.org.au" %>
           </li>
         </ul>
       </nav>


### PR DESCRIPTION
* contact email was going to info@ruby.org.au which was bouncing
* point at contact@ruby.org.au instead