### PR TITLE
Add new postal contact info + move contact to its own page

### DIFF
--- a/app/controllers/contact_controller.rb
+++ b/app/controllers/contact_controller.rb
@@ -1,0 +1,2 @@
+class ContactController < ApplicationController
+end

--- a/app/views/contact/us.html.erb
+++ b/app/views/contact/us.html.erb
@@ -1,0 +1,17 @@
+<h1>Contact Ruby Australia</h1>
+
+<ul>
+  <li>
+    <%= link_to 'Twitter (@rubyaustralia)', "http://twitter.com/rubyaustralia" %>
+  </li>
+  <li>
+    <%= link_to 'Email', "mailto:contact@ruby.org.au" %>
+  </li>
+</ul>
+
+<p>Or via post:</p>
+
+Ruby Australia<br>
+PO Box 221<br>
+Collins Street West, VIC 8007, Australia
+

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -91,15 +91,7 @@
           </li>
         </ul>
 
-        <h3>Contact us</h3>
-        <ul>
-          <li>
-            <%= link_to 'Twitter', "http://twitter.com/rubyaustralia" %>
-          </li>
-          <li>
-            <%= link_to 'Email', "mailto:contact@ruby.org.au" %>
-          </li>
-        </ul>
+        <h3><%= link_to "Contact us", "/contact" %></h3>
       </nav>
     </aside>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,13 +12,11 @@ Rails.application.routes.draw do
   delete "/sign_out" => "clearance/sessions#destroy", as: "sign_out"
   get "/sign_up" => "users#new", as: "sign_up"
   get "/just_joined" => "users#just_joined", as: "just_joined"
-  # For details on the DSL available within this file,
-  # see http://guides.rubyonrails.org/routing.html
 
-  # Serve websocket cable requests in-process
-  # mount ActionCable.server => '/cable'
   root to: 'welcome#index'
   resources :welcome, only: [:index]
+
+  get '/contact', to: "contact#us"
 
   # URL backwards compatibility
   # remove after July 2017 or so


### PR DESCRIPTION
Moved the contact info out of the sidebar and into its own page. Here's what it looks like:

![image](https://user-images.githubusercontent.com/2687/28302094-b585eb60-6bce-11e7-8dae-2aaf78f3f245.png)

