### PR TITLE
Fix notice display

### DIFF
--- a/app/views/pages/_notice.html.erb
+++ b/app/views/pages/_notice.html.erb
@@ -1,6 +1,6 @@
 <section class="divider-1 text-white py-6 justify-center" style="background-image: url(<%= asset_url('roro-pattern.png') %>)">
   <div class="md:ml-10 max-w-md mx-4 justify-center text-center">
-    <a class="border-pink border-2 text-pink font-mono no-underline hover:bg-pink hover:text-white text-bold bg-white py-2 px-5 shadow-md" href="<%= url %>" title="<%= title %>">
+    <a class="inline-block border-pink border-2 text-pink font-mono no-underline hover:bg-pink hover:text-white text-bold bg-white py-2 px-5 shadow-md" href="<%= url %>" title="<%= title %>">
       <%= text %>
     </a>
   </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7039523/58216291-ad54e600-7cc3-11e9-9fa9-e2e74b7f771b.png)

The survey link on smaller screens looks weird as you can in the above screenshot.

This PR fixes it by adding `inline-block` class to the link inside `_notice.html.erb`

![image](https://user-images.githubusercontent.com/7039523/58216318-ce1d3b80-7cc3-11e9-916e-8b517da5bd79.png)
