### PR TITLE
Rails girls web site address

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: ruby
 cache: bundler
 before_script:
+  - psql -c 'create database ruby_au_test;' -U postgres >/dev/null
   - bundle exec rake db:create db:schema:load
   - yarn install
   - bundle exec rails webpacker:compile
 script:
   - bundle exec rspec
   - bundle exec rubocop
+services:
+  - postgresql

--- a/app/views/pages/rails-girls.html.erb
+++ b/app/views/pages/rails-girls.html.erb
@@ -4,7 +4,7 @@
   <section id="welcome" class="flex flex-1 flex-col border-l-2 border-grey-lighter md:mt-5">
     <article class="welcome">
       <p>
-        Rails Girls is a global, non-profit volunteer community that provides tools and a community for women to understand technology and to build their ideas.
+        Rails Girls is a global, non-profit volunteer community that provides tools and a community for women to understand technology and to build their ideas. You can find more information on the <%= link_to_external "Rails Girls website.", "http://railsgirls.com/" %>
       </p>
 
       <p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,11 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "yarn": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.16.0.tgz",
+      "integrity": "sha512-cfemyGlnWKA1zopUUgebTPf8C4WkPIZ+TJmklwcEAJ4u6oWPtJeAzrsamaGGh/+b1XWe8W51yzAImC4AWbWR1g=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "dependencies": {
     "@rails/webpacker": "4.0",
     "jquery": "^3.4.0",
-    "tailwindcss": "^0.7.4"
+    "tailwindcss": "^0.7.4",
+    "yarn": "^1.16.0"
   },
   "devDependencies": {
     "autoprefixer": "^9.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7299,3 +7299,8 @@ yargs@^7.0.0:
     which-module "^1.0.0"
     y18n "^3.2.1"
     yargs-parser "^5.0.0"
+
+yarn@^1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.16.0.tgz#5701b58ac555ff91f7b889b7d791b3dc86f8f999"
+  integrity sha512-cfemyGlnWKA1zopUUgebTPf8C4WkPIZ+TJmklwcEAJ4u6oWPtJeAzrsamaGGh/+b1XWe8W51yzAImC4AWbWR1g==


### PR DESCRIPTION
### Context
As a visitor to Ruby Australia's website, it might be useful to find a little more information about Rails Girls. Conveniently, Rails Girls has a really lovely (and useful) website. Therefore, to get regularly updated information on everything Rails Girls, including upcoming events, tips and community, it might be useful to provide a link to the Rails Girls website on Ruby Australia's website.

Before:
<img width="644" alt="Screen Shot 2019-06-12 at 9 34 33 pm" src="https://user-images.githubusercontent.com/20434999/59348284-0d3a2c00-8d5a-11e9-8ba9-07d469d96a3b.png">

After:
<img width="639" alt="Screen Shot 2019-06-12 at 9 34 43 pm" src="https://user-images.githubusercontent.com/20434999/59348342-2e9b1800-8d5a-11e9-9603-360a5c3e801c.png">

Official site:
<img width="1374" alt="Screen Shot 2019-06-12 at 9 35 17 pm" src="https://user-images.githubusercontent.com/20434999/59348504-a701d900-8d5a-11e9-9410-9f200c11de1e.png">

### Done When
Link to Rails Girls website exists on Ruby Australia's page.