### PR TITLE
Committee flag for users.

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -1,0 +1,12 @@
+class Admin::ApplicationController < ApplicationController
+  before_action :authenticate_user!
+  before_action :confirm_is_committee!
+
+  private
+
+  def confirm_is_committee!
+    return if current_user.committee?
+
+    redirect_to root_path
+  end
+end

--- a/app/controllers/admin/memberships_controller.rb
+++ b/app/controllers/admin/memberships_controller.rb
@@ -1,3 +1,3 @@
 class Admin::MembershipsController < Admin::ApplicationController
-  expose(:members) { Membership.current }
+  expose(:members) { Membership.current.includes(:user) }
 end

--- a/app/controllers/admin/memberships_controller.rb
+++ b/app/controllers/admin/memberships_controller.rb
@@ -1,0 +1,3 @@
+class Admin::MembershipsController < Admin::ApplicationController
+  expose(:members) { Membership.current }
+end

--- a/app/helpers/committee_helper.rb
+++ b/app/helpers/committee_helper.rb
@@ -1,0 +1,5 @@
+module CommitteeHelper
+  def current_committee?
+    user_signed_in? && current_user.committee?
+  end
+end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -6,6 +6,8 @@ class Membership < ApplicationRecord
 
   scope :current, -> { where(left_at: nil) }
 
+  delegate :full_name, to: :user
+
   private
 
   def single_current_membership

--- a/app/views/admin/memberships/index.html.erb
+++ b/app/views/admin/memberships/index.html.erb
@@ -1,0 +1,13 @@
+<%= content_for :heading do %>
+  Current Memberships
+<% end %>
+
+<h2>Ruby Australia Members</h2>
+
+<article>
+  <ul>
+    <% members.each do |member| %>
+      <li><%= member.full_name %> (since <%= member.joined_at.to_date.to_s(:db) %>)</li>
+    <% end %>
+  </ul>
+</article>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -76,6 +76,13 @@
             <li><%= link_to_external "Videos", videos_path %></li>
             <li><%= link_to_external 'Mailing List', "/mailing-list" %></li>
           </ul>
+
+          <% if current_committee? %>
+            <h3>Committee</h3>
+            <ul>
+              <li><%= link_to "Members", admin_memberships_path %></li>
+            </ul>
+          <% end %>
         </section>
       </div>
     </nav>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,10 @@ Rails.application.routes.draw do
 
   resources :reactivations, only: [:new, :create]
 
+  namespace :admin do
+    resources :memberships, only: [:index]
+  end
+
   get '/forum', to: redirect('https://forum.ruby.org.au'),
     as: :forum
   get '/mailing-list', to: redirect('https://confirmsubscription.com/h/j/3DDD74A0ACC3DB22'),

--- a/db/migrate/20190722041810_add_committee_to_users.rb
+++ b/db/migrate/20190722041810_add_committee_to_users.rb
@@ -1,0 +1,5 @@
+class AddCommitteeToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :committee, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_24_133733) do
+ActiveRecord::Schema.define(version: 2019_07_22_041810) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(version: 2019_06_24_133733) do
     t.string "unconfirmed_email"
     t.text "address"
     t.datetime "deactivated_at"
+    t.boolean "committee", default: false, null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/spec/features/committee_manages_members_spec.rb
+++ b/spec/features/committee_manages_members_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe "Committee managing members", type: :feature do
+  let(:user) { FactoryBot.create(:user, committee: true) }
+
+  before do
+    log_in_as user
+  end
+
+  scenario "views the list of current members" do
+    FactoryBot.create(:user, full_name: "Alex")
+    FactoryBot.create(:user, full_name: "Jules", confirmed_at: nil)
+    riley = FactoryBot.create(:user, full_name: "Riley")
+
+    visit root_path
+    click_link "Members"
+    expect(page).to have_content "Alex"
+    expect(page).to_not have_content "Jules"
+    expect(page).to have_content "Riley"
+
+    riley.memberships.current.update left_at: 1.minute.ago
+
+    click_link "Members"
+    expect(page).to have_content "Alex"
+    expect(page).to_not have_content "Riley"
+  end
+end


### PR DESCRIPTION
Something simple - if users are marked as committee, they can view extra interface things. In this case, it's just a simple list of current members. There'll be further PRs to build on top of this: managing member imports, membership registry stuff, and likely pagination for this view as well.