### PR TITLE
Fix for registrations: allow `visible` param.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:full_name, :address])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:full_name, :address, :visible])
   end
 
   private

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -27,6 +27,10 @@ Rails.application.configure do
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
+
+  # Raise strong parameter errors.
+  config.action_controller.action_on_unpermitted_parameters = :raise
+
   config.action_mailer.perform_caching = false
 
   # Tell Action Mailer not to deliver emails to the real world.


### PR DESCRIPTION
The fact Rails doesn’t default to raising exceptions in the test environment puzzles me - especially because our new registrations form has been broken since it was rolled out the other week. 🤦‍♂