### PR TITLE
Import and invite members from attendance CSVs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,9 @@ group :development do
 end
 
 group :test do
+  gem 'capybara-email',
+      git: 'https://github.com/cgunther/capybara-email.git',
+      branch: 'capybara-3.17-click_on-disabled'
   gem 'rails-controller-testing'
   gem "codeclimate-test-reporter", require: nil
   gem "simplecov", require: nil

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/cgunther/capybara-email.git
+  revision: d97947d5e705e537f9875a9ec44c0de3457be6ba
+  branch: capybara-3.17-click_on-disabled
+  specs:
+    capybara-email (3.0.1)
+      capybara (>= 2.4, < 4.0)
+      mail
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -283,6 +292,7 @@ DEPENDENCIES
   bugsnag
   byebug
   capybara
+  capybara-email!
   codeclimate-test-reporter
   decent_exposure
   devise

--- a/app/controllers/admin/imported_members_controller.rb
+++ b/app/controllers/admin/imported_members_controller.rb
@@ -1,5 +1,5 @@
 class Admin::ImportedMembersController < Admin::ApplicationController
-  expose(:members) { ImportedMember.uncontacted }
+  expose(:members) { ImportedMember.contactable }
 
   def create
     CSV.read(create_params[:file].tempfile, headers: true, header_converters: :symbol).each do |row|

--- a/app/controllers/admin/imported_members_controller.rb
+++ b/app/controllers/admin/imported_members_controller.rb
@@ -16,6 +16,8 @@ class Admin::ImportedMembersController < Admin::ApplicationController
   end
 
   def add_import(row)
+    return if User.where(email: row[:email]).any?
+
     member = ImportedMember.find_or_initialize_by(email: row[:email])
     member.data_will_change!
 

--- a/app/controllers/admin/imported_members_controller.rb
+++ b/app/controllers/admin/imported_members_controller.rb
@@ -22,6 +22,7 @@ class Admin::ImportedMembersController < Admin::ApplicationController
     member.data_will_change!
 
     member.full_name ||= row[:name]
+    member.contacted_at = nil
     member.data['sources'] ||= []
     member.data['sources'] << create_params[:source]
     member.save!

--- a/app/controllers/admin/imported_members_controller.rb
+++ b/app/controllers/admin/imported_members_controller.rb
@@ -1,0 +1,27 @@
+class Admin::ImportedMembersController < Admin::ApplicationController
+  expose(:members) { ImportedMember.uncontacted }
+
+  def create
+    CSV.read(create_params[:file].tempfile, headers: true, header_converters: :symbol).each do |row|
+      add_import row
+    end
+
+    redirect_to admin_imported_members_path
+  end
+
+  private
+
+  def create_params
+    @create_params ||= params.slice(:source, :file)
+  end
+
+  def add_import(row)
+    member = ImportedMember.find_or_initialize_by(email: row[:email])
+    member.data_will_change!
+
+    member.full_name ||= row[:name]
+    member.data['sources'] ||= []
+    member.data['sources'] << create_params[:source]
+    member.save!
+  end
+end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,0 +1,36 @@
+class InvitationsController < ApplicationController
+  expose(:user) { User.new user_params }
+  expose(:imported_member) { ImportedMember.find_by token: params[:id] }
+
+  def create
+    if user.valid?
+      user.confirmed_at = Time.current
+      user.save!
+
+      sign_in user
+
+      redirect_to root_path, notice: "Your membership to Ruby Australia has been confirmed."
+    else
+      render :new
+    end
+  end
+
+  def unsubscribe
+    imported_member.update unsubscribed_at: Time.current
+
+    redirect_to root_path, notice: "You have been unsubscribed from membership invitations."
+  end
+
+  private
+
+  def user_params
+    hash = params.fetch(:user, {}).permit(
+      :full_name, :email, :password, :password_confirmation, :address, :visible
+    )
+
+    hash[:full_name] ||= imported_member.full_name
+    hash[:email]     ||= imported_member.email
+
+    hash
+  end
+end

--- a/app/lib/send_invitations.rb
+++ b/app/lib/send_invitations.rb
@@ -1,0 +1,19 @@
+class SendInvitations
+  def self.call
+    new.call
+  end
+
+  def call
+    imported_members.each do |member|
+      MemberInvitationMailer.invite(member).deliver_now
+
+      member.update contacted_at: Time.current
+    end
+  end
+
+  private
+
+  def imported_members
+    ImportedMember.contactable
+  end
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'no-reply@ruby.org.au'
+  default from: 'online@ruby.org.au'
   layout 'mailer'
 end

--- a/app/mailers/member_invitation_mailer.rb
+++ b/app/mailers/member_invitation_mailer.rb
@@ -1,0 +1,10 @@
+class MemberInvitationMailer < ApplicationMailer
+  def invite(imported_member)
+    @imported_member = imported_member
+
+    mail(
+      to: @imported_member.email,
+      subject: 'Ruby Australia Membership'
+    )
+  end
+end

--- a/app/models/imported_member.rb
+++ b/app/models/imported_member.rb
@@ -1,2 +1,3 @@
 class ImportedMember < ApplicationRecord
+  scope :uncontacted, -> { where(contacted_at: nil) }
 end

--- a/app/models/imported_member.rb
+++ b/app/models/imported_member.rb
@@ -1,5 +1,7 @@
 class ImportedMember < ApplicationRecord
   scope :uncontacted, -> { where(contacted_at: nil) }
+  scope :subscribed,  -> { where(unsubscribed_at: nil) }
+  scope :contactable, -> { uncontacted.subscribed }
 
   validates :full_name, presence: true
   validates :email, presence: true

--- a/app/models/imported_member.rb
+++ b/app/models/imported_member.rb
@@ -12,6 +12,6 @@ class ImportedMember < ApplicationRecord
   private
 
   def set_token
-    self.token = SecureRandom.uuid
+    self.token ||= SecureRandom.uuid
   end
 end

--- a/app/models/imported_member.rb
+++ b/app/models/imported_member.rb
@@ -1,0 +1,2 @@
+class ImportedMember < ApplicationRecord
+end

--- a/app/models/imported_member.rb
+++ b/app/models/imported_member.rb
@@ -1,3 +1,15 @@
 class ImportedMember < ApplicationRecord
   scope :uncontacted, -> { where(contacted_at: nil) }
+
+  validates :full_name, presence: true
+  validates :email, presence: true
+  validates :token, presence: true, uniqueness: true
+
+  before_validation :set_token, on: :create
+
+  private
+
+  def set_token
+    self.token = SecureRandom.uuid
+  end
 end

--- a/app/views/admin/imported_members/index.html.erb
+++ b/app/views/admin/imported_members/index.html.erb
@@ -1,0 +1,42 @@
+<%= content_for :heading do %>
+  Imported Members
+<% end %>
+
+<h2>Imported Members</h2>
+
+<%= form_tag admin_imported_members_path, method: :post, multipart: true, class: "standard" do %>
+  <div class="field">
+    <div class="label">
+      <%= label_tag :source, "Source", class: "required" %>
+    </div>
+    <div class="input">
+      <%= text_field_tag :source %>
+    </div>
+    <div class="hint">
+      When we send an email to confirm the membership, we use this text to indicate where the details were sourced from. An example: "Rails Camp 25".
+    </div>
+  </div>
+
+  <div class="field">
+    <div class="label">
+      <%= label_tag :file, "CSV File", class: "required" %>
+    </div>
+    <div class="input">
+      <%= file_field_tag :file %>
+    </div>
+  </div>
+
+  <div class="buttons">
+    <%= submit_tag "Upload" %>
+  </div>
+<% end %>
+
+<article>
+  <p>These people are not yet confirmed Ruby Australia members. Their details have been imported from an event attendee list.</p>
+
+  <ul>
+    <% members.each do |member| %>
+      <li><%= member.full_name %></li>
+    <% end %>
+  </ul>
+</article>

--- a/app/views/invitations/new.html.erb
+++ b/app/views/invitations/new.html.erb
@@ -1,0 +1,90 @@
+<%= content_for :heading do %>
+  Confirm Membership
+<% end %>
+
+<%= form_for(user, url: invitation_path(imported_member.token), html: {class: "standard"}) do |f| %>
+  <%= render "devise/shared/error_messages", resource: user %>
+
+  <p class="info">To become a member of Ruby Australia we ask for both authentication details (to ensure only you can update your details later), and membership details (as required by law).</p>
+
+  <p class="info">While membership details can be accessed by other members (again, it's a legal requirement), this is only for purposes related directly to the association. Your details <em>will not</em> be shared with anyone else, and will not be used for spam, undesired marketing, etc.</p>
+
+  <fieldset>
+    <legend>Authentication Details</legend>
+
+    <div class="field">
+      <div class="label">
+        <%= f.label :email %>
+      </div>
+      <div class="input">
+        <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+      </div>
+    </div>
+
+    <div class="field">
+      <div class="label">
+        <%= f.label :password %>
+      </div>
+      <div class="input">
+        <%= f.password_field :password, autocomplete: "new-password" %>
+      </div>
+      <% if @minimum_password_length %>
+        <div class="hint">
+          <em>(<%= @minimum_password_length %> characters minimum)</em>
+        </div>
+      <% end %>
+    </div>
+
+    <div class="field">
+      <div class="label">
+        <%= f.label :password_confirmation %>
+      </div>
+      <div class="input">
+        <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+      </div>
+    </div>
+  </fieldset>
+
+  <fieldset>
+    <legend>Membership Details</legend>
+
+    <p class="info">We have a <%= link_to_external "legal requirement", "https://www.consumer.vic.gov.au/clubs-and-fundraising/incorporated-associations/running-an-incorporated-association/membership" %> to have all members' names and addresses on file. Other members can request to review them, but we have a strict process around this to avoid abuse.</p>
+
+    <div class="field">
+      <div class="label">
+        <%= f.label :full_name, class: 'required' %>
+      </div>
+      <div class="input">
+        <%= f.text_field :full_name %>
+      </div>
+    </div>
+
+    <div class="field">
+      <div class="label">
+        <%= f.label :address, class: 'required' %>
+      </div>
+      <div class="input">
+        <%= f.text_area :address %>
+      </div>
+    </div>
+
+    <div class="field flipped">
+      <div class="input">
+        <%= f.check_box :visible %>
+      </div>
+      <div class="label">
+        <%= f.label :visible, 'Visible on Members Registry' %>
+      </div>
+      <div class="hint">
+        The registry is only viewable to other members on request, and with supervision from a committee member. Still, we can <%= link_to_external "retract your details", "https://www.consumer.vic.gov.au/clubs-and-fundraising/incorporated-associations/running-an-incorporated-association/membership#restricting-access-to-personal-information" %> if you wish.
+      </div>
+    </div>
+  </fieldset>
+
+  <p class="links">By signing up, you agree to
+    the <%= link_to "Ruby Australia Terms and Conditions", "/terms-and-conditions" %>.</p>
+
+  <div class="buttons">
+    <%= f.submit "Register" %>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -81,6 +81,7 @@
             <h3>Committee</h3>
             <ul>
               <li><%= link_to "Members", admin_memberships_path %></li>
+              <li><%= link_to "Imported Members", admin_imported_members_path %></li>
             </ul>
           <% end %>
         </section>

--- a/app/views/member_invitation_mailer/invite.html.erb
+++ b/app/views/member_invitation_mailer/invite.html.erb
@@ -1,0 +1,21 @@
+<p>Hi <%= @imported_member.full_name %>,</p>
+
+<p><strong>If you're not sure what Ruby Australia is, please read the details below!</strong> We at Ruby Australia are in the process of validating our records of members, and we're keen to confirm people's interest in being a member. From our records, you have attended the following events, which have given you implicit membership of Ruby Australia:</p>
+
+<ul>
+  <% @imported_member.data["sources"].each do |source| %>
+    <li><%= source %></li>
+  <% end %>
+</ul>
+
+<p>If you wish to continue being a member of Ruby Australia (it doesn't cost anything!), we need to confirm your details for our records:</p>
+
+<p class="confirm"><%= link_to "Confirm Membership", invitation_url(@imported_member.token) %></p>
+
+<p>Ruby Australia is the organisation behind many Ruby-related events across Australia, including Rails Camps, RubyConf AU, RailsGirls, and monthly meets in many cities. We provide financial and logistical support to event organisers, and seek to grow and improve the Ruby community across the country. As a confirmed member, you get to attend and vote at our general meetings, and be nominated (by yourself or others) for a position in the association's committee.</p>
+
+<p>You do not need to be a member of Ruby Australia to attend any of our events, though by attending you are agreeing to behave in accordance with our <%= link_to "Code of Conduct", page_url("code-of-conduct") %>. If you do not wish to receive any of these membership invitation emails for future events you may attend, you can <%= link_to "unsubscribe", unsubscribe_invitation_url(@imported_member.token) %>. If you change your mind at any point, you're able to <%= link_to "sign up as a member", new_user_registration_url %> on our website without needing to attend any events.</p>
+
+<p>Take care and have fun,</p>
+
+<p>-- <br />The Ruby Australia Committee</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :memberships, only: [:index]
+    resources :imported_members, only: [:index, :create]
   end
 
   get '/forum', to: redirect('https://forum.ruby.org.au'),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,13 @@ Rails.application.routes.draw do
     resources :imported_members, only: [:index, :create]
   end
 
+  resources :invitations, only: [] do
+    member do
+      get :unsubscribe, :new
+      post :create
+    end
+  end
+
   get '/forum', to: redirect('https://forum.ruby.org.au'),
     as: :forum
   get '/mailing-list', to: redirect('https://confirmsubscription.com/h/j/3DDD74A0ACC3DB22'),

--- a/db/migrate/20190722051647_create_imported_members.rb
+++ b/db/migrate/20190722051647_create_imported_members.rb
@@ -1,0 +1,13 @@
+class CreateImportedMembers < ActiveRecord::Migration[5.2]
+  def change
+    create_table :imported_members do |t|
+      t.string :full_name, null: false
+      t.string :email, null: false
+      t.json :data, null: false, default: {}
+      t.datetime :contacted_at
+      t.timestamps null: false
+    end
+
+    add_index :imported_members, :email
+  end
+end

--- a/db/migrate/20190722075252_add_token_to_imported_members.rb
+++ b/db/migrate/20190722075252_add_token_to_imported_members.rb
@@ -1,0 +1,5 @@
+class AddTokenToImportedMembers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :imported_members, :token, :string, null: false
+  end
+end

--- a/db/migrate/20190725061450_add_index_to_invited_tokens.rb
+++ b/db/migrate/20190725061450_add_index_to_invited_tokens.rb
@@ -1,0 +1,5 @@
+class AddIndexToInvitedTokens < ActiveRecord::Migration[5.2]
+  def change
+    add_index :imported_members, :token, unique: true
+  end
+end

--- a/db/migrate/20190725061631_add_unsubscribed_at_to_imported_members.rb
+++ b/db/migrate/20190725061631_add_unsubscribed_at_to_imported_members.rb
@@ -1,0 +1,7 @@
+class AddUnsubscribedAtToImportedMembers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :imported_members, :unsubscribed_at, :datetime
+    add_index :imported_members, :unsubscribed_at
+    add_index :imported_members, :contacted_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_22_041810) do
+ActiveRecord::Schema.define(version: 2019_07_22_051647) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "imported_members", force: :cascade do |t|
+    t.string "full_name", null: false
+    t.string "email", null: false
+    t.json "data", default: {}, null: false
+    t.datetime "contacted_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_imported_members_on_email"
+  end
 
   create_table "memberships", force: :cascade do |t|
     t.bigint "user_id", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_22_075252) do
+ActiveRecord::Schema.define(version: 2019_07_25_061631) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,7 +23,11 @@ ActiveRecord::Schema.define(version: 2019_07_22_075252) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "token", null: false
+    t.datetime "unsubscribed_at"
+    t.index ["contacted_at"], name: "index_imported_members_on_contacted_at"
     t.index ["email"], name: "index_imported_members_on_email"
+    t.index ["token"], name: "index_imported_members_on_token", unique: true
+    t.index ["unsubscribed_at"], name: "index_imported_members_on_unsubscribed_at"
   end
 
   create_table "memberships", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_22_051647) do
+ActiveRecord::Schema.define(version: 2019_07_22_075252) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 2019_07_22_051647) do
     t.datetime "contacted_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "token", null: false
     t.index ["email"], name: "index_imported_members_on_email"
   end
 

--- a/lib/tasks/imported_members.rake
+++ b/lib/tasks/imported_members.rake
@@ -1,0 +1,6 @@
+namespace :imported_members do
+  desc "Invite not-yet-contacted imported members from events"
+  task invite: :environment do
+    SendInvitations.call
+  end
+end

--- a/spec/factories/imported_member.rb
+++ b/spec/factories/imported_member.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :imported_member do
+    sequence :full_name do |n|
+      "full_name_#{n}"
+    end
+    sequence :email do |n|
+      "user#{n}@example.com"
+    end
+
+    data { { "sources" => ["Rails Camp"] } }
+  end
+end

--- a/spec/features/committee_imports_members_spec.rb
+++ b/spec/features/committee_imports_members_spec.rb
@@ -15,7 +15,12 @@ RSpec.describe "Committee importing members", type: :feature do
       csv << ["Alex", "alex@ruby.test"]
       csv << ["Jules", "jules@ruby.test"]
       csv << ["Riley", "riley@ruby.test"]
+      csv << ["Lindsay", "lindsay@ruby.test"]
     end
+
+    FactoryBot.create(:user, email: "lindsay@ruby.test")
+    jules = FactoryBot.create(:user, email: "jules@ruby.test")
+    jules.memberships.current.update left_at: 1.minute.ago
 
     camp = Tempfile.new("camp")
     camp.write output
@@ -28,8 +33,9 @@ RSpec.describe "Committee importing members", type: :feature do
     click_button "Upload"
 
     expect(page).to have_content("Alex")
-    expect(page).to have_content("Jules")
     expect(page).to have_content("Riley")
+    expect(page).to_not have_content("Jules")
+    expect(page).to_not have_content("Lindsay")
 
     camp.close
 

--- a/spec/features/committee_imports_members_spec.rb
+++ b/spec/features/committee_imports_members_spec.rb
@@ -101,5 +101,18 @@ RSpec.describe "Committee importing members", type: :feature do
       member = ImportedMember.find_by(email: "dylan@ruby.test")
       expect(member.unsubscribed_at).to be_present
     end
+
+    scenario "respects unsubscribes" do
+      ImportedMember.find_each { |member| member.update contacted_at: nil }
+      ImportedMember.find_by(email: "dylan@ruby.test").update(
+        unsubscribed_at: Time.current
+      )
+
+      clear_emails
+      SendInvitations.call
+
+      expect(emails_sent_to("riley@ruby.test")).to_not be_empty
+      expect(emails_sent_to("dylan@ruby.test")).to be_empty
+    end
   end
 end

--- a/spec/features/committee_imports_members_spec.rb
+++ b/spec/features/committee_imports_members_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+require "tempfile"
+require "csv"
+
+RSpec.describe "Committee importing members", type: :feature do
+  let(:user) { FactoryBot.create(:user, committee: true) }
+
+  before do
+    log_in_as user
+  end
+
+  scenario "via CSV file" do
+    output = CSV.generate do |csv|
+      csv << %w[name email]
+      csv << ["Alex", "alex@ruby.test"]
+      csv << ["Jules", "jules@ruby.test"]
+      csv << ["Riley", "riley@ruby.test"]
+    end
+
+    camp = Tempfile.new("camp")
+    camp.write output
+    camp.rewind
+
+    click_link "Imported Members"
+
+    fill_in "Source", with: "Rails Camp"
+    attach_file "CSV File", camp.path
+    click_button "Upload"
+
+    expect(page).to have_content("Alex")
+    expect(page).to have_content("Jules")
+    expect(page).to have_content("Riley")
+
+    camp.close
+
+    output = CSV.generate do |csv|
+      csv << %w[name email]
+      csv << ["Riley", "riley@ruby.test"]
+      csv << ["Dylan", "dylan@ruby.test"]
+    end
+    conf = Tempfile.new("conf")
+    conf.write output
+    conf.rewind
+
+    fill_in "Source", with: "RubyConf AU"
+    attach_file "CSV File", conf.path
+    click_button "Upload"
+
+    expect(page).to have_content("Riley", count: 1)
+    expect(page).to have_content("Dylan")
+
+    conf.close
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,8 @@ require 'spec_helper'
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
+require 'capybara/email/rspec'
+
 Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each do |file|
   require file
 end


### PR DESCRIPTION
This is not the most elegant code/structure, but I feel like it's good enough for now. Essentially, you can import CSVs of attendees from events, and then send invitations to them to confirm their Ruby Australia memberships.

It's best done by importing all the different events, and then sending the invites in one go, so people will only receive one email (rather than one per event). They have the option of unsubscribing from future membership requests as well.

The email copy is written from the perspective of right now with our imperfect membership list, but should change once the standard behaviour flows are more established. The email template is not ideal either, but that can be a separate PR (as all of our emails need some work to be more clearly Ruby AU branded).