### PR TITLE
Adding Register Access Policy

### DIFF
--- a/app/controllers/policies_controller.rb
+++ b/app/controllers/policies_controller.rb
@@ -1,0 +1,20 @@
+class PoliciesController < ApplicationController
+  expose(:policies) do
+    documents.select { |document| document.context['status'] == 'published' }
+  end
+  expose(:policy) do
+    policies.detect { |document| document.context['key'] == params[:id] }
+  end
+
+  def show
+    return if policy.present?
+
+    raise ActionController::RoutingError, "No such policy: #{params[:id]}"
+  end
+
+  private
+
+  def documents
+    ContextDocument.all_within Rails.root.join("app", "documents", "policies")
+  end
+end

--- a/app/documents/policies/register_access_policy.markdown
+++ b/app/documents/policies/register_access_policy.markdown
@@ -1,0 +1,30 @@
+name: Membership Register Access Policy
+key: register-access
+status: published
+version: 2019-07-29
+---
+## Why We Need It
+
+As part of running an association, [under Victorian consumer law](https://www.consumer.vic.gov.au/clubs-and-fundraising/incorporated-associations/running-an-incorporated-association/membership) Ruby Australia is required to let our members view each others' details at no cost. This helps with membership transparency, democracy, and communication - it means the committee is not the sole arbiter for discussions between members.
+
+We do want to stress that contacting members through the details obtained from the register can only be done for matters relating to the association. Any abuse of this responsibility will be dealt with swiftly and seriously.
+
+## Member Privacy
+
+Alongside our desire for transparancy, Ruby Australia also wants to protect our members' privacy - only revealing their details when necessary. Hence, there is this policy, and alongside it there is a document of any access requests made by members, which is viewable to all members.
+
+When managing their information, members are able to indicate for their details to be restricted. This removes their details from the register, but they may still be contacted via a request to the Ruby Australia Secretary.
+
+## Accessing Details
+
+Ruby Australia does not allow programmatic access to membership details (including approaches such as CSV exports, HTTP APIs, or copy-and-paste). Details will be presented through either a video call organised by a committee member, or on a committee member's computer during an in-person meeting with the interested parties.
+
+While this does mean there is significant overhead for contacting members, it is worth noting that other avenues of contacting members is also available through the association's forum and Slack workspace.
+
+## The Process
+
+* A member sends an email to the committee via online@ruby.org.au requesting to view the membership register, optionally providing a reason for the request.
+* A committee member will respond within seven days, offering possible times and dates for the viewing. They will also document the request.
+* The viewing will take place either in person (with the list viewable on a committee member's computer), or via a video call (with the list viewable via a shared screen of a committee member's computer).
+* If the requesting member wishes to contact members whose details have been restricted, they can send a message to secretary@ruby.org.au, which will be passed on to members accordingly.
+* Once the viewing has taken place, the responsible committee member will update the document of requests indicating that this particular request has been completed.

--- a/app/lib/context_document.rb
+++ b/app/lib/context_document.rb
@@ -1,0 +1,27 @@
+class ContextDocument
+  MARKER = /---\s*/.freeze
+
+  def self.all_within(directory)
+    Dir["#{directory}/*"].collect { |path| new(path) }
+  end
+
+  def initialize(path)
+    @path = path
+  end
+
+  def context
+    @context ||= YAML.safe_load input.split(MARKER).first.strip
+  end
+
+  def document
+    @document ||= input.split(MARKER).last.strip
+  end
+
+  private
+
+  attr_reader :path
+
+  def input
+    @input ||= File.read path
+  end
+end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -5,9 +5,9 @@
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: {class: "standard"}) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
-  <p class="info">To become a member of Ruby Australia we ask for both authentication details (to ensure only you can update your details later), and membership details (as required by law).</p>
+  <p class="info">To become a member of Ruby Australia we ask for both <strong>authentication details</strong> (to ensure only you can update your details later), and <strong>membership details</strong> (as required by law).</p>
 
-  <p class="info">While membership details can be accessed by other members (again, it's a legal requirement), this is only for purposes related directly to the association. Your details <em>will not</em> be shared with anyone else, and will not be used for spam, undesired marketing, etc.</p>
+  <p class="info">While membership details <%= link_to "can be accessed by other members", policy_path("register-access") %>, this is only for purposes related directly to the association. Your details <em>will not</em> be shared with anyone else, and will not be used for spam, undesired marketing, etc.</p>
 
   <fieldset>
     <legend>Authentication Details</legend>
@@ -48,7 +48,7 @@
   <fieldset>
     <legend>Membership Details</legend>
 
-    <p class="info">We have a <%= link_to_external "legal requirement", "https://www.consumer.vic.gov.au/clubs-and-fundraising/incorporated-associations/running-an-incorporated-association/membership" %> to have all members' names and addresses on file. Other members can request to review them, but we have a strict process around this to avoid abuse.</p>
+    <p class="info">We have a <%= link_to_external "legal requirement", "https://www.consumer.vic.gov.au/clubs-and-fundraising/incorporated-associations/running-an-incorporated-association/membership" %> to have all members' names and addresses on file. Other members can request to review them, but <%= link_to "we have a strict process", policy_path("register-access") %> around this to avoid abuse.</p>
 
     <div class="field">
       <div class="label">
@@ -76,7 +76,7 @@
         <%= f.label :visible, 'Visible on Members Registry' %>
       </div>
       <div class="hint">
-        The registry is only viewable to other members on request, and with supervision from a committee member. Still, we can <%= link_to_external "retract your details", "https://www.consumer.vic.gov.au/clubs-and-fundraising/incorporated-associations/running-an-incorporated-association/membership#restricting-access-to-personal-information" %> if you wish.
+        The registry is only viewable to other members, and <em>only</em> with <%= link_to "supervision from a committee member", policy_path("register-access") %>. Still, you can retract your details if you wish.
       </div>
     </div>
   </fieldset>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -57,6 +57,7 @@
             <li><%= link_to_external "Meeting Minutes", "https://forum.ruby.org.au/c/ruby-au/meetings", longdesc: 'Committee Meeting minutes hosted on RubyAU Forums' %></li>
             <li><%= link_to 'Code of Conduct', "/code-of-conduct" %></li>
             <li><%= link_to 'Constitution', "/constitution" %></li>
+            <li><%= link_to 'Policies', "/policies" %></li>
             <li><%= link_to 'Sponsorship', "/sponsorship" %></li>
             <li><%= link_to "Contact us", "/contact" %></li>
           </ul>

--- a/app/views/policies/index.html.erb
+++ b/app/views/policies/index.html.erb
@@ -1,0 +1,13 @@
+<%= content_for :heading do %>
+  Policies
+<% end %>
+
+<h2>Published Policies</h2>
+
+<ul>
+  <% policies.each do |policy| %>
+    <li><%= link_to policy.context['name'], policy_path(policy.context['key']) %></li>
+  <% end %>
+</ul>
+
+<p>All published policies are listed above. Draft policies can be found (or proposed) in the GitHub repository.</p>

--- a/app/views/policies/show.html.erb
+++ b/app/views/policies/show.html.erb
@@ -1,0 +1,11 @@
+<%= content_for :heading do %>
+  <%= policy.context['name'] %>
+<% end %>
+
+<div class="markdown">
+  <h1>Ruby Australia's <%= policy.context['name'] %></h1>
+
+  <p>Version: <strong><%= policy.context['version'] %></strong></p>
+
+  <%= markdown_to_html policy.document %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,8 @@ Rails.application.routes.draw do
 
   root to: 'pages#show', defaults: { id: 'welcome' }
 
+  get "/policies" => "policies#index", as: :policies
+  get "/policies/*id" => "policies#show", as: :policy
   get "/sponsors/*id" => 'sponsors#show'
   get "/*id" => 'pages#show', as: :page, format: false,
     constraints: RootRouteConstraints


### PR DESCRIPTION
This PR sets up some general structures around handling policy documents, as well as adding an initial policy for how association members can access the member register (and how we protect the privacy of our members as well).

Policy documents live in `app/documents/policies`, and are expected to be Markdown files with Jekyll-style YAML frontmatter. That frontmatter must have the following keys:

* `name`: A human-friendly name of the document, used in headings. e.g. “Diversity and Inclusion Policy”
* `key`: a dash-separated identifier to use in URLs. e.g. “diversity-and-inclusion”
* `version`: a date is perhaps best, to help with historical context. e.g. “2019-07-30”
* `status`: optional, but only policies with this set to “published” will actually be visible on the site. Anything else is considered a draft.

This PR does _not_ implement the register, nor the access request list. They'll be done in a separate PR (**Edit**: see #105).

Also: I personally feel like the Code of Conduct and related documents (enforcement and reporting) should be migrated to live in this policies approach. Others' opinions on this are very welcome - and if it were to happen, we'd want redirects from the old URLs as well.