### PR TITLE
Create CM webhooks and listen to them.

### DIFF
--- a/app/controllers/mailing_lists_controller.rb
+++ b/app/controllers/mailing_lists_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class MailingListsController < ApplicationController
+  def hook
+    events.each do |event|
+      handle_list_event event
+    end
+  end
+
+  private
+
+  def events
+    JSON.parse(request.body.read)["Events"]
+  end
+
+  def handle_list_event(event)
+    user = User.find_by email: event["EmailAddress"]
+    return if user.nil?
+
+    user.mailing_lists_will_change!
+
+    case event["Type"]
+    when "Subscribe"
+      user.mailing_lists[list.name] = "true"
+    when "Deactivate"
+      user.mailing_lists[list.name] = "false"
+    end
+
+    user.save
+  end
+
+  def list
+    @list ||= MailingList.all.detect { |list| list.api_id == params[:id] }
+  end
+end

--- a/app/lib/mailing_list/create_webhooks.rb
+++ b/app/lib/mailing_list/create_webhooks.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class MailingList::CreateWebhooks
+  def self.call
+    MailingList.all.each do |list|
+      new(list).call
+    end
+  end
+
+  def initialize(list)
+    @list = list
+  end
+
+  def call
+    routes.default_url_options = Rails.application.config.action_mailer.default_url_options
+
+    cm_list.create_webhook(
+      %w[Subscribe Deactivate], # events
+      routes.url_helpers.hook_mailing_list_url(list.api_id), # url
+      "json" # format
+    )
+  end
+
+  private
+
+  attr_reader :list
+
+  def cm_auth
+    { api_key: ENV['CAMPAIGN_MONITOR_API_KEY'] }
+  end
+
+  def cm_list
+    @cm_list ||= CreateSend::List.new cm_auth, list.api_id
+  end
+
+  def routes
+    Rails.application.routes
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,10 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :mailing_lists, only: [] do
+    member { post :hook }
+  end
+
   get '/forum', to: redirect('https://forum.ruby.org.au'),
     as: :forum
   get '/mailing-list', to: redirect('https://confirmsubscription.com/h/j/3DDD74A0ACC3DB22'),

--- a/lib/tasks/mailing_lists.rake
+++ b/lib/tasks/mailing_lists.rake
@@ -5,4 +5,9 @@ namespace :mailing_lists do
   task sync: :environment do
     MailingList::Sync.call
   end
+
+  desc "Set up webhooks for each mailing list"
+  task webhooks: :environment do
+    MailingList::CreateWebhooks.call
+  end
 end

--- a/spec/features/committee_manages_list_webhooks_spec.rb
+++ b/spec/features/committee_manages_list_webhooks_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Committee manages list webhooks", type: :request do
+  scenario "registering webhooks" do
+    MailingList.all.each do |list|
+      stub_request(:post, "https://api.createsend.com/api/v3.2/lists/#{list.api_id}/webhooks.json")
+    end
+
+    MailingList::CreateWebhooks.call
+
+    MailingList.all.each do |list|
+      expect(
+        a_request(:post, "https://api.createsend.com/api/v3.2/lists/#{list.api_id}/webhooks.json")
+      ).to have_been_made
+    end
+  end
+
+  scenario "calling a webhook" do
+    list = MailingList.all.first
+    alex = FactoryBot.create :user, mailing_lists: { list.name => "true" }
+    jules = FactoryBot.create :user
+
+    body = <<~JSON
+      {
+        "Events": [
+          {
+            "EmailAddress": "#{alex.email}",
+            "Type": "Deactivate"
+          },
+          {
+            "EmailAddress": "#{jules.email}",
+            "Type": "Subscribe"
+          }
+        ],
+        "ListID": "#{list.api_id}"
+      }
+    JSON
+
+    post hook_mailing_list_url(list.api_id), params: body, headers: { 'Content-Type' => 'application/json' }
+
+    alex.reload
+    jules.reload
+
+    expect(alex.mailing_lists[list.name]).to eq("false")
+    expect(jules.mailing_lists[list.name]).to eq("true")
+  end
+end

--- a/spec/features/committee_sychronises_mailing_lists_spec.rb
+++ b/spec/features/committee_sychronises_mailing_lists_spec.rb
@@ -2,8 +2,8 @@
 
 require "rails_helper"
 
-RSpec.describe "Committee synchonising mailing lists", type: :feature do
-  it "updates user flags" do
+RSpec.feature "Committee synchonising mailing lists", type: :feature do
+  scenario "updates user flags" do
     alex = FactoryBot.create(
       :user, mailing_lists: { 'RubyConf AU' => "false", 'RailsGirls' => "true" }
     )


### PR DESCRIPTION
This takes care of staying on top of sub/unsubs on the mailing lists to keep local flags up-to-date.

We’re not storing the webhook ids to refer to them later, but the odds of creating more than one are slim (as it’ll require CLI access to the app), and it’s not too hard to dive into a console and clean things up should mistakes get made.

I should have included this in #107 but didn't think to implement it at the time, oops.