### PR TITLE
Consolidate Code of Conduct documents under Policies

### DIFF
--- a/app/controllers/policies_controller.rb
+++ b/app/controllers/policies_controller.rb
@@ -15,6 +15,8 @@ class PoliciesController < ApplicationController
   private
 
   def documents
-    ContextDocument.all_within Rails.root.join("app", "documents", "policies")
+    ContextDocument.all_within(
+      Rails.root.join("app", "documents", "policies")
+    ).sort_by { |document| document.context['name'] }
   end
 end

--- a/app/documents/policies/code_of_conduct.markdown
+++ b/app/documents/policies/code_of_conduct.markdown
@@ -5,6 +5,10 @@ version: "0.7 (2018-05-17)"
 ---
 ## Matz is nice, and we are nice.
 
+> To report an incident, please review the [reporting guide](/policies/code-of-conduct-reporting) and email conduct@ruby.org.au.
+>
+> Reports will be handled with the process outlined in our [enforcement policy](/policies/code-of-conduct-enforcement).
+
 In the same way that Matz has written Ruby with a focus on developer happiness, we are focused on community happiness. The Australian Ruby community is full of wonderful people from a diverse range of backgrounds, and we want to ensure it remains a welcoming and safe environment to all who wish to be a part of it.
 
 Whenever we come together as a community, our shared spaces are opportunities to showcase the best of what we can be. We are there to support our peers - to build each other up, to accept each other for who they are, and to encourage each other to become the people they want to be.

--- a/app/documents/policies/code_of_conduct.markdown
+++ b/app/documents/policies/code_of_conduct.markdown
@@ -1,5 +1,8 @@
-# Ruby Australia's Code of Conduct
-
+name: Code of Conduct
+key: code-of-conduct
+status: published
+version: "0.7 (2018-05-17)"
+---
 ## Matz is nice, and we are nice.
 
 In the same way that Matz has written Ruby with a focus on developer happiness, we are focused on community happiness. The Australian Ruby community is full of wonderful people from a diverse range of backgrounds, and we want to ensure it remains a welcoming and safe environment to all who wish to be a part of it.
@@ -76,5 +79,3 @@ conduct@ruby.org.au
 This Code of Conduct is distributed under a Creative Commons Attribution-ShareAlike license.
 
 Portions of text derived from the Django Code of Conduct, the Geek Feminism Anti-Harassment Policy and the Ruby New Zealand Code of Conduct.
-
-_Revision 0.7, 17 May 2018._

--- a/app/documents/policies/code_of_conduct_enforcement.markdown
+++ b/app/documents/policies/code_of_conduct_enforcement.markdown
@@ -1,4 +1,8 @@
-# Code of Conduct Enforcement
+name: Code of Conduct Enforcement Policy
+key: code-of-conduct-enforcement
+status: published
+version: "0.3 (2018-05-17)"
+---
 
 This is the enforcement manual followed by Ruby Australia's Disciplinary Subcommittee. It's used when we respond to an issue to make sure we're consistent and fair. It should be considered an internal document.
 
@@ -15,7 +19,7 @@ See the reporting guidelines for details of what reports should contain. If a re
 The subcommittee will then review the incident and determine, to the best of their ability:
 
 - what happened,
-- whether this event constitutes a code of conduct violation, 
+- whether this event constitutes a code of conduct violation,
 - who, if anyone, was the bad actor, and
 - whether this is an ongoing situation, and there is a threat to anyone's physical safety.
 
@@ -58,5 +62,3 @@ In the event of any conflict of interest a subcommittee member must immediately 
 This enforcement manual is distributed under a Creative Commons Attribution-ShareAlike license.
 
 Portions of text derived from the Django Enforcement Manual.
-
-_Revision 0.3, 17 May 2018._

--- a/app/documents/policies/code_of_conduct_enforcement.markdown
+++ b/app/documents/policies/code_of_conduct_enforcement.markdown
@@ -1,4 +1,4 @@
-name: Code of Conduct Enforcement Policy
+name: Code of Conduct - Enforcement Policy
 key: code-of-conduct-enforcement
 status: published
 version: "0.3 (2018-05-17)"

--- a/app/documents/policies/code_of_conduct_reporting.markdown
+++ b/app/documents/policies/code_of_conduct_reporting.markdown
@@ -1,5 +1,8 @@
-# Code of Conduct - Reporting Guide
-
+name: Code of Conduct - Reporting Guide
+key: code-of-conduct-reporting
+status: published
+version: "0.4 (2018-05-17)"
+---
 ## Making a report
 If you believe someone is violating the code of conduct we ask that you report it to:
 
@@ -59,5 +62,3 @@ Only permanent resolutions (such as bans) may be appealed. To appeal a decision 
 This reporting guide is distributed under a Creative Commons Attribution-ShareAlike license.
 
 Portions of text derived from the Django Code of Conduct Reporting Guide.
-
-_Revision 0.4, 17 May 2018._

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -58,7 +58,7 @@
             <li><%= link_to "Welcome", "/" %></li>
             <li><%= link_to 'Committee Members', "/committee-members" %></li>
             <li><%= link_to_external "Meeting Minutes", "https://forum.ruby.org.au/c/ruby-au/meetings", longdesc: 'Committee Meeting minutes hosted on RubyAU Forums' %></li>
-            <li><%= link_to 'Code of Conduct', "/code-of-conduct" %></li>
+            <li><%= link_to 'Code of Conduct', "/policies/code-of-conduct" %></li>
             <li><%= link_to 'Constitution', "/constitution" %></li>
             <li><%= link_to 'Policies', "/policies" %></li>
             <li><%= link_to 'Sponsorship', "/sponsorship" %></li>

--- a/app/views/pages/code-of-conduct-enforcement.html.erb
+++ b/app/views/pages/code-of-conduct-enforcement.html.erb
@@ -1,5 +1,0 @@
-<%= content_for :heading do %>
-  Code of Conduct: Enforcement
-<% end %>
-
-<%= document_markdown_to_html "code-of-conduct-enforcement" %>

--- a/app/views/pages/code-of-conduct-reporting.html.erb
+++ b/app/views/pages/code-of-conduct-reporting.html.erb
@@ -1,5 +1,0 @@
-<%= content_for :heading do %>
-  Code of Conduct: Reporting
-<% end %>
-
-<%= document_markdown_to_html "code-of-conduct-reporting" %>

--- a/app/views/pages/code-of-conduct.html.erb
+++ b/app/views/pages/code-of-conduct.html.erb
@@ -1,5 +1,0 @@
-<%= content_for :heading do %>
-  Code of Conduct
-<% end %>
-
-<%= document_markdown_to_html "code-of-conduct" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,6 +53,10 @@ Rails.application.routes.draw do
   get "/sponsorship" => 'sponsors#index'
   get "/sponsors/*id" => 'sponsors#show'
 
+  get "/code-of-conduct", to: redirect("/policies/code-of-conduct")
+  get "/code-of-conduct-enforcement", to: redirect("/policies/code-of-conduct-enforcement")
+  get "/code-of-conduct-reporting", to: redirect("/policies/code-of-conduct-reporting")
+
   get "/*id" => 'pages#show', as: :page, format: false,
     constraints: RootRouteConstraints
 end


### PR DESCRIPTION
They can now sit alongside our Register Access Policy. I've added redirects to ensure the old paths continue to work - and this does not change the _content_ of the Code of Conduct, Enforcement and Reporting policies.