### PR TITLE
Generic Email Campaigns

### DIFF
--- a/app/controllers/admin/campaigns_controller.rb
+++ b/app/controllers/admin/campaigns_controller.rb
@@ -5,6 +5,7 @@ class Admin::CampaignsController < Admin::ApplicationController
   expose(:campaign) do
     params[:id] ? Campaign.find(params[:id]) : Campaign.new(campaign_params)
   end
+  expose(:events) { RsvpEvent.order(happens_at: :desc) }
 
   before_action :deny_if_sent, only: %i[update destroy]
 

--- a/app/controllers/admin/campaigns_controller.rb
+++ b/app/controllers/admin/campaigns_controller.rb
@@ -6,6 +6,8 @@ class Admin::CampaignsController < Admin::ApplicationController
     params[:id] ? Campaign.find(params[:id]) : Campaign.new(campaign_params)
   end
 
+  before_action :deny_if_sent, only: %i[update destroy]
+
   def create
     if campaign.save
       redirect_to admin_campaigns_path, notice: "Your campaign has been created."
@@ -22,9 +24,21 @@ class Admin::CampaignsController < Admin::ApplicationController
     end
   end
 
+  def destroy
+    campaign.destroy
+
+    redirect_to admin_campaigns_path, notice: "Your campaign has been deleted."
+  end
+
   private
 
   def campaign_params
     params.fetch(:campaign, {}).permit(:subject, :preheader, :content, :rsvp_event_id)
+  end
+
+  def deny_if_sent
+    return unless campaign.delivered?
+
+    redirect_to admin_campaigns_path, notice: "This campaign has already been sent."
   end
 end

--- a/app/controllers/admin/campaigns_controller.rb
+++ b/app/controllers/admin/campaigns_controller.rb
@@ -9,6 +9,15 @@ class Admin::CampaignsController < Admin::ApplicationController
 
   before_action :deny_if_sent, only: %i[update destroy]
 
+  def show
+    membership = current_user.memberships.current.first
+    mail = CampaignsMailer.campaign_email campaign, membership
+
+    # rubocop:disable Rails/OutputSafety
+    render html: mail.body.to_s.html_safe, layout: nil
+    # rubocop:enable Rails/OutputSafety
+  end
+
   def create
     if campaign.save
       redirect_to admin_campaigns_path, notice: "Your campaign has been created."

--- a/app/controllers/admin/campaigns_controller.rb
+++ b/app/controllers/admin/campaigns_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Admin::CampaignsController < Admin::ApplicationController
+  expose(:campaigns) { Campaign.order(created_at: :desc).page params[:page] }
+  expose(:campaign) do
+    params[:id] ? Campaign.find(params[:id]) : Campaign.new(campaign_params)
+  end
+
+  def create
+    if campaign.save
+      redirect_to admin_campaigns_path, notice: "Your campaign has been created."
+    else
+      render :new
+    end
+  end
+
+  def update
+    if campaign.update campaign_params
+      redirect_to admin_campaigns_path, notice: "Your campaign has been updated."
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def campaign_params
+    params.fetch(:campaign, {}).permit(:subject, :preheader, :content, :rsvp_event_id)
+  end
+end

--- a/app/helpers/campaigns_helper.rb
+++ b/app/helpers/campaigns_helper.rb
@@ -1,0 +1,22 @@
+module CampaignsHelper
+  def substituted_content(campaign, rsvp)
+    content = substitute_content campaign.content, rsvp
+
+    markdown_to_html content
+  end
+
+  # rubocop:disable Rails/OutputSafety
+  def substitute_content(content, rsvp)
+    return content if rsvp.nil?
+
+    content.gsub(
+      '{{ rsvp_links }}',
+      tag.p(
+        "#{link_to 'Yes', confirm_rsvp_url(rsvp.token)} " \
+        "#{link_to 'No', decline_rsvp_url(rsvp.token)}".html_safe,
+        class: 'button'
+      )
+    )
+  end
+  # rubocop:enable Rails/OutputSafety
+end

--- a/app/lib/campaigns/send.rb
+++ b/app/lib/campaigns/send.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class Campaigns::Send
+  def self.call(campaign)
+    new(campaign).call
+  end
+
+  def initialize(campaign)
+    @campaign = campaign
+  end
+
+  def call
+    return if campaign.delivered_at.present?
+
+    campaign.update delivered_at: Time.current
+
+    Membership.current.each do |membership|
+      CampaignsMailer.campaign_email(campaign, membership).deliver_now
+    end
+  end
+
+  private
+
+  attr_reader :campaign
+end

--- a/app/lib/campaigns/send.rb
+++ b/app/lib/campaigns/send.rb
@@ -12,14 +12,27 @@ class Campaigns::Send
   def call
     return if campaign.delivered_at.present?
 
-    campaign.update delivered_at: Time.current
-
     Membership.current.each do |membership|
+      delivery = delivery_for membership
+      next if delivery.delivered_at.present?
+
       CampaignsMailer.campaign_email(campaign, membership).deliver_now
+
+      delivery.delivered_at = Time.current
+      delivery.save!
     end
+
+    campaign.update delivered_at: Time.current
   end
 
   private
 
   attr_reader :campaign
+
+  def delivery_for(membership)
+    CampaignDelivery.find_or_initialize_by(
+      campaign: campaign,
+      membership: membership
+    )
+  end
 end

--- a/app/mailers/campaigns_mailer.rb
+++ b/app/mailers/campaigns_mailer.rb
@@ -2,6 +2,7 @@
 
 class CampaignsMailer < ApplicationMailer
   helper :application
+  helper :campaigns
 
   def campaign_email(campaign, membership)
     @membership = membership

--- a/app/mailers/campaigns_mailer.rb
+++ b/app/mailers/campaigns_mailer.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class CampaignsMailer < ApplicationMailer
+  helper :application
+
+  def campaign_email(campaign, membership)
+    @membership = membership
+    @campaign = campaign
+
+    prepare_event_variables campaign
+
+    mail(
+      to: @membership.user.email,
+      subject: campaign.subject
+    )
+  end
+
+  private
+
+  def prepare_event_variables(campaign)
+    return if campaign.rsvp_event.blank?
+
+    @event = campaign.rsvp_event
+    @rsvp = Rsvp.find_or_create_by(
+      rsvp_event: @event,
+      membership: @membership
+    )
+  end
+end

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -1,0 +1,3 @@
+class Campaign < ApplicationRecord
+  belongs_to :rsvp_event, optional: true
+end

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -1,3 +1,7 @@
 class Campaign < ApplicationRecord
   belongs_to :rsvp_event, optional: true
+
+  def delivered?
+    delivered_at.present?
+  end
 end

--- a/app/models/campaign_delivery.rb
+++ b/app/models/campaign_delivery.rb
@@ -1,0 +1,4 @@
+class CampaignDelivery < ApplicationRecord
+  belongs_to :campaign
+  belongs_to :membership
+end

--- a/app/views/admin/campaigns/_form.html.erb
+++ b/app/views/admin/campaigns/_form.html.erb
@@ -13,6 +13,15 @@
 
   <div class="field">
     <div class="label">
+      <%= form.label :rsvp_event_id %>
+    </div>
+    <div class="input">
+      <%= form.select :rsvp_event_id, events.collect { |event| [event.title, event.id] }, include_blank: true %>
+    </div>
+  </div>
+
+  <div class="field">
+    <div class="label">
       <%= form.label :subject, class: "required" %>
     </div>
     <div class="input">

--- a/app/views/admin/campaigns/_form.html.erb
+++ b/app/views/admin/campaigns/_form.html.erb
@@ -1,0 +1,44 @@
+<%= form_for [:admin, campaign], html: {class: "standard"} do |form| %>
+  <% if campaign.errors.any? %>
+    <div id="error_explanation" class="ui visible error message">
+      <h2><%= pluralize(campaign.errors.count, "error") %> prohibited this from being saved:</h2>
+
+      <ul>
+        <% campaign.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <div class="label">
+      <%= form.label :subject, class: "required" %>
+    </div>
+    <div class="input">
+      <%= form.text_field :subject %>
+    </div>
+  </div>
+
+  <div class="field">
+    <div class="label">
+      <%= form.label :preheader, class: "required" %>
+    </div>
+    <div class="input">
+      <%= form.text_field :preheader %>
+    </div>
+  </div>
+
+  <div class="field">
+    <div class="label">
+      <%= form.label :content, class: "required" %>
+    </div>
+    <div class="input">
+      <%= form.text_area :content %>
+    </div>
+  </div>
+
+  <div class="buttons">
+    <%= form.submit "Save" %>
+  </div>
+<% end %>

--- a/app/views/admin/campaigns/edit.html.erb
+++ b/app/views/admin/campaigns/edit.html.erb
@@ -1,0 +1,9 @@
+<%= content_for :heading do %>
+  Email Campaigns
+<% end %>
+
+<h2>Edit Campaign</h2>
+
+<article>
+  <%= render partial: "form" %>
+</article>

--- a/app/views/admin/campaigns/index.html.erb
+++ b/app/views/admin/campaigns/index.html.erb
@@ -23,6 +23,7 @@
           <td><%= campaign.rsvp_event&.title %></td>
           <td><%= campaign.delivered_at || "Not yet" %></td>
           <td>
+            <%= link_to "Preview", admin_campaign_path(campaign), target: "_blank" %>
             <% unless campaign.delivered? %>
               <%= link_to "Edit", edit_admin_campaign_path(campaign) %>
               <%= link_to "Delete", admin_campaign_path(campaign), method: :delete, data: {confirm: "Are you sure? Deletion is permanent."} %>

--- a/app/views/admin/campaigns/index.html.erb
+++ b/app/views/admin/campaigns/index.html.erb
@@ -1,0 +1,32 @@
+<%= content_for :heading do %>
+  Email Campaigns
+<% end %>
+
+<h2>Campaigns</h2>
+
+<article>
+  <p class="button"><%= link_to "Add", new_admin_campaign_path %></p>
+
+  <table class="member-list">
+    <thead>
+      <tr>
+        <th>Subject</th>
+        <th>Event</th>
+        <th>Sent At</th>
+        <th>&nbsp;</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% campaigns.each do |campaign| %>
+        <tr>
+          <td><%= campaign.subject %></td>
+          <td><%= campaign.rsvp_event&.title %></td>
+          <td><%= campaign.delivered_at || "Not yet" %></td>
+          <td><%= link_to "Edit", edit_admin_campaign_path(campaign) %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <%= paginate campaigns %>
+</article>

--- a/app/views/admin/campaigns/index.html.erb
+++ b/app/views/admin/campaigns/index.html.erb
@@ -13,7 +13,7 @@
         <th>Subject</th>
         <th>Event</th>
         <th>Sent At</th>
-        <th>&nbsp;</th>
+        <th>Actions</th>
       </tr>
     </thead>
     <tbody>
@@ -22,7 +22,12 @@
           <td><%= campaign.subject %></td>
           <td><%= campaign.rsvp_event&.title %></td>
           <td><%= campaign.delivered_at || "Not yet" %></td>
-          <td><%= link_to "Edit", edit_admin_campaign_path(campaign) %></td>
+          <td>
+            <% unless campaign.delivered? %>
+              <%= link_to "Edit", edit_admin_campaign_path(campaign) %>
+              <%= link_to "Delete", admin_campaign_path(campaign), method: :delete, data: {confirm: "Are you sure? Deletion is permanent."} %>
+            <% end %>
+          </td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/admin/campaigns/new.html.erb
+++ b/app/views/admin/campaigns/new.html.erb
@@ -1,0 +1,9 @@
+<%= content_for :heading do %>
+  Email Campaigns
+<% end %>
+
+<h2>New Campaign</h2>
+
+<article>
+  <%= render partial: "form" %>
+</article>

--- a/app/views/campaigns_mailer/campaign_email.html.erb
+++ b/app/views/campaigns_mailer/campaign_email.html.erb
@@ -2,4 +2,4 @@
 <%= @campaign.preheader %>
 <% end %>
 
-<%= markdown_to_html @campaign.content %>
+<%= substituted_content @campaign, @rsvp %>

--- a/app/views/campaigns_mailer/campaign_email.html.erb
+++ b/app/views/campaigns_mailer/campaign_email.html.erb
@@ -1,0 +1,5 @@
+<%= content_for :preheader do %>
+<%= @campaign.preheader %>
+<% end %>
+
+<%= markdown_to_html @campaign.content %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -93,6 +93,7 @@
               <li><%= link_to "Members", admin_memberships_path %></li>
               <li><%= link_to "Access Requests", admin_access_requests_path %></li>
               <li><%= link_to "Imported Members", admin_imported_members_path %></li>
+              <li><%= link_to "Campaigns", admin_campaigns_path %></li>
             </ul>
           <% end %>
         </section>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,6 +24,7 @@ en:
     label:
       campaign:
         preheader: "Pre-Header"
+        rsvp_event_id: "Event"
       rsvp:
         proxy_name: "Your Proxy's Name"
         proxy_signature: "Your Signature"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,11 +22,13 @@
 en:
   helpers:
     label:
+      campaign:
+        preheader: "Pre-Header"
+      rsvp:
+        proxy_name: "Your Proxy's Name"
+        proxy_signature: "Your Signature"
       user:
         address: 'Postal Address'
         full_name: 'Full Name'
         password_confirmation: 'Confirm Password'
         preferred_name: 'Preferred Name'
-      rsvp:
-        proxy_name: "Your Proxy's Name"
-        proxy_signature: "Your Signature"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
     resources :memberships, only: [:index]
     resources :access_requests, except: [:destroy]
     resources :imported_members, only: [:index, :create]
+    resources :campaigns
   end
 
   resources :invitations, only: [] do

--- a/db/migrate/20191007082552_create_campaigns.rb
+++ b/db/migrate/20191007082552_create_campaigns.rb
@@ -1,0 +1,12 @@
+class CreateCampaigns < ActiveRecord::Migration[5.2]
+  def change
+    create_table :campaigns do |t|
+      t.references :rsvp_event, null: true, foreign_key: true
+      t.string :subject, null: false
+      t.string :preheader, null: false
+      t.text :content
+      t.datetime :delivered_at
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20191007111808_create_campaign_deliveries.rb
+++ b/db/migrate/20191007111808_create_campaign_deliveries.rb
@@ -1,0 +1,10 @@
+class CreateCampaignDeliveries < ActiveRecord::Migration[5.2]
+  def change
+    create_table :campaign_deliveries do |t|
+      t.references :campaign, foreign_key: true
+      t.references :membership, foreign_key: true
+      t.datetime :delivered_at, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_11_135217) do
+ActiveRecord::Schema.define(version: 2019_10_07_082552) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,17 @@ ActiveRecord::Schema.define(version: 2019_09_11_135217) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["recorder_id"], name: "index_access_requests_on_recorder_id"
+  end
+
+  create_table "campaigns", force: :cascade do |t|
+    t.bigint "rsvp_event_id"
+    t.string "subject", null: false
+    t.string "preheader", null: false
+    t.text "content"
+    t.datetime "delivered_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["rsvp_event_id"], name: "index_campaigns_on_rsvp_event_id"
   end
 
   create_table "imported_members", force: :cascade do |t|
@@ -105,6 +116,7 @@ ActiveRecord::Schema.define(version: 2019_09_11_135217) do
   end
 
   add_foreign_key "access_requests", "users", column: "recorder_id"
+  add_foreign_key "campaigns", "rsvp_events"
   add_foreign_key "memberships", "users"
   add_foreign_key "rsvps", "memberships"
   add_foreign_key "rsvps", "rsvp_events"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_07_082552) do
+ActiveRecord::Schema.define(version: 2019_10_07_111808) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,16 @@ ActiveRecord::Schema.define(version: 2019_10_07_082552) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["recorder_id"], name: "index_access_requests_on_recorder_id"
+  end
+
+  create_table "campaign_deliveries", force: :cascade do |t|
+    t.bigint "campaign_id"
+    t.bigint "membership_id"
+    t.datetime "delivered_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["campaign_id"], name: "index_campaign_deliveries_on_campaign_id"
+    t.index ["membership_id"], name: "index_campaign_deliveries_on_membership_id"
   end
 
   create_table "campaigns", force: :cascade do |t|
@@ -116,6 +126,8 @@ ActiveRecord::Schema.define(version: 2019_10_07_082552) do
   end
 
   add_foreign_key "access_requests", "users", column: "recorder_id"
+  add_foreign_key "campaign_deliveries", "campaigns"
+  add_foreign_key "campaign_deliveries", "memberships"
   add_foreign_key "campaigns", "rsvp_events"
   add_foreign_key "memberships", "users"
   add_foreign_key "rsvps", "memberships"

--- a/lib/tasks/campaigns.rake
+++ b/lib/tasks/campaigns.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+namespace :campaigns do
+  desc "Send emails for a given campaign"
+  task send: :environment do
+    Campaigns::Send.call Campaign.find(ENV["CAMPAIGN_ID"])
+  end
+end

--- a/spec/factories/campaign.rb
+++ b/spec/factories/campaign.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :campaign do
+    subject { "News" }
+    preheader { "Please Read Me" }
+    content { "Not much to say..." }
+  end
+end

--- a/spec/features/committee_manages_email_campaign_spec.rb
+++ b/spec/features/committee_manages_email_campaign_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Committee manages email campaigns", type: :feature do
+  let(:user) { FactoryBot.create(:user, committee: true) }
+
+  before :each do
+    log_in_as user
+  end
+
+  scenario "create a new stand-alone campaign" do
+    FactoryBot.create(:user, full_name: "Alex", email: "alex@ruby.test")
+
+    click_link "Campaigns"
+    click_link "Add"
+
+    fill_in "Subject", with: "Random News"
+    fill_in "Pre-Header", with: "Please read me"
+    fill_in "Content", with: "Here's the latest from Ruby Australia"
+    click_button "Save"
+
+    Campaigns::Send.call Campaign.first
+
+    self.current_email = emails_sent_to("alex@ruby.test").detect do |mail|
+      mail.subject == "Random News"
+    end
+    expect(current_email).to be_present
+  end
+
+  scenario "editing a campaign" do
+    FactoryBot.create(:campaign, subject: "Latest News")
+
+    click_link "Campaigns"
+    click_link "Edit"
+
+    fill_in "Subject", with: "Random News"
+    click_button "Save"
+
+    expect(page).to have_content("Random News")
+    expect(page).to_not have_content("Lates News")
+  end
+end

--- a/spec/features/committee_manages_email_campaign_spec.rb
+++ b/spec/features/committee_manages_email_campaign_spec.rb
@@ -33,6 +33,27 @@ RSpec.describe "Committee manages email campaigns", type: :feature do
     expect(page).to_not have_content("Delete")
   end
 
+  scenario "create a new campaign with an event" do
+    FactoryBot.create(:user, full_name: "Alex", email: "alex@ruby.test")
+    FactoryBot.create(:rsvp_event, title: "AGM")
+
+    click_link "Campaigns"
+    click_link "Add"
+
+    select "AGM", from: "Event"
+    fill_in "Subject", with: "Random News"
+    fill_in "Pre-Header", with: "Please read me"
+    fill_in "Content", with: "Here's the latest from Ruby Australia"
+    click_button "Save"
+
+    Campaigns::Send.call Campaign.first
+
+    self.current_email = emails_sent_to("alex@ruby.test").detect do |mail|
+      mail.subject == "Random News"
+    end
+    expect(current_email).to be_present
+  end
+
   scenario "editing a campaign" do
     FactoryBot.create(:campaign, subject: "Latest News")
 

--- a/spec/features/committee_manages_email_campaign_spec.rb
+++ b/spec/features/committee_manages_email_campaign_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe "Committee manages email campaigns", type: :feature do
 
   before :each do
     log_in_as user
+
+    clear_emails
   end
 
   scenario "create a new stand-alone campaign" do
@@ -43,7 +45,7 @@ RSpec.describe "Committee manages email campaigns", type: :feature do
     select "AGM", from: "Event"
     fill_in "Subject", with: "Random News"
     fill_in "Pre-Header", with: "Please read me"
-    fill_in "Content", with: "Here's the latest from Ruby Australia"
+    fill_in "Content", with: "Can you make it?\n\n{{ rsvp_links }}"
     click_button "Save"
 
     Campaigns::Send.call Campaign.first
@@ -52,6 +54,9 @@ RSpec.describe "Committee manages email campaigns", type: :feature do
       mail.subject == "Random News"
     end
     expect(current_email).to be_present
+
+    current_email.click_link "Yes"
+    expect(page).to have_content("Thanks for confirming your attendance")
   end
 
   scenario "editing a campaign" do

--- a/spec/features/committee_manages_email_campaign_spec.rb
+++ b/spec/features/committee_manages_email_campaign_spec.rb
@@ -81,4 +81,18 @@ RSpec.describe "Committee manages email campaigns", type: :feature do
     expect(page).to have_content("Your campaign has been deleted.")
     expect(page).to_not have_content("Latest News")
   end
+
+  scenario "sending campaigns" do
+    user = FactoryBot.create(:user, email: "alex@ruby.test")
+    campaign = FactoryBot.create(:campaign)
+
+    Campaigns::Send.call campaign
+    Campaigns::Send.call campaign
+
+    emails = emails_sent_to(user.email).select do |mail|
+      mail.subject == campaign.subject
+    end
+
+    expect(emails.length).to eq(1)
+  end
 end

--- a/spec/features/committee_manages_email_campaign_spec.rb
+++ b/spec/features/committee_manages_email_campaign_spec.rb
@@ -26,6 +26,11 @@ RSpec.describe "Committee manages email campaigns", type: :feature do
       mail.subject == "Random News"
     end
     expect(current_email).to be_present
+
+    click_link "Campaigns"
+    expect(page).to have_content("Random News")
+    expect(page).to_not have_content("Edit")
+    expect(page).to_not have_content("Delete")
   end
 
   scenario "editing a campaign" do
@@ -38,6 +43,16 @@ RSpec.describe "Committee manages email campaigns", type: :feature do
     click_button "Save"
 
     expect(page).to have_content("Random News")
-    expect(page).to_not have_content("Lates News")
+    expect(page).to_not have_content("Latest News")
+  end
+
+  scenario "deleting a campaign" do
+    FactoryBot.create(:campaign, subject: "Latest News")
+
+    click_link "Campaigns"
+    click_link "Delete"
+
+    expect(page).to have_content("Your campaign has been deleted.")
+    expect(page).to_not have_content("Latest News")
   end
 end


### PR DESCRIPTION
As promised in #110, here's a PR that provides the functionality for admins/committee to send emails to members without hard-coding it into the app 😅

The email templates are expected to be Markdown, and the one piece of substitution is that - _if_ a campaign is associated with a specific event - you can have `{{ rsvp_links }}` in the Markdown content, and it'll be changed into Yes and No links with that member's personal RSVP token.

Actually sending the campaigns is solely done through a rake task - it'll take too long for a web request, and I'm still holding back from adding a background worker for such infrequently-used features.