### PR TITLE
Simple registration field to stop spammers.

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class RegistrationsController < Devise::RegistrationsController
+  # rubocop:disable Rails/LexicallyScopedActionFilter
+  before_action :confirm_human, only: [:create]
+  # rubocop:enable Rails/LexicallyScopedActionFilter
+
+  private
+
+  def confirm_human
+    return unless params[:human_verification].downcase['ruby'].nil?
+
+    build_resource(sign_up_params)
+
+    flash[:alert] = "Something wasn't quite right."
+    render :new
+  end
+end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -99,6 +99,21 @@
     </fieldset>
   </fieldset>
 
+  <fieldset>
+    <legend>One last thing…</legend>
+
+    <div class="hint">Please enter the text 'Ruby' in the text field below. This is just to avoid spambots signing up. 😅</div>
+
+    <div class="field">
+      <div class="label">
+        <%= label_tag :human_verification, "Ruby?", class: 'required' %>
+      </div>
+      <div class="input">
+        <%= text_field_tag :human_verification %>
+      </div>
+    </div>
+  </fieldset>
+
   <p class="links">By signing up, you agree to
     the <%= link_to "Ruby Australia Terms and Conditions", "/terms-and-conditions" %>.</p>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: { registrations: 'registrations' }
 
   namespace :my do
     resource :details, only: [:show, :edit, :update]

--- a/spec/features/visitor_signs_up_spec.rb
+++ b/spec/features/visitor_signs_up_spec.rb
@@ -33,6 +33,25 @@ RSpec.feature "Visitor signs up", type: :feature do
     expect_user_not_to_be_registered
   end
 
+  scenario "as a bot" do
+    visit new_user_registration_path
+
+    fill_in "Email", with: "valid@example.com"
+    fill_in "Password", with: "password"
+    fill_in "Confirm Password", with: "password"
+    fill_in "Full Name", with: 'Jane Doe'
+    fill_in "Postal Address", with: '1 High Street'
+
+    check "Rails Camp"
+
+    fill_in "Ruby?", with: "Random bot generated string"
+
+    click_button 'Register'
+
+    expect_user_not_to_be_registered
+    expect(User.count).to be_zero
+  end
+
   def sign_up_with(email, password)
     visit new_user_registration_path
 
@@ -43,6 +62,8 @@ RSpec.feature "Visitor signs up", type: :feature do
     fill_in "Postal Address", with: '1 High Street'
 
     check "Rails Camp"
+
+    fill_in "Ruby?", with: "Ruby"
 
     click_button 'Register'
   end


### PR DESCRIPTION
We’re getting hundreds of spam registrations each week - and while they’re not being confirmed (and thus don’t end up on our list of members), it’s still extra emails and database rows that I’d rather avoid.

So, this commit just adds another field to the registration form - and if it’s not filled in with ‘Ruby’ (any case, any part of the string - I like being flexible), then the registration is blocked.