### PR TITLE
tweak/sponsor logos displayed on welcome page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -5,6 +5,10 @@ class PagesController < ApplicationController
 
   expose(:complex_view?) { COMPLEX_VIEWS.include? params[:id] }
 
+  expose(:sponsors) do
+    YAML.load_file Rails.root.join('config/data/sponsors.yml')
+  end
+
   rescue_from ActionView::MissingTemplate do |exception|
     if exception.message.match?(/Missing template pages#{request.path}/)
       raise ActionController::RoutingError, "No such page: #{params[:id]}"

--- a/app/views/pages/welcome.html.erb
+++ b/app/views/pages/welcome.html.erb
@@ -40,7 +40,7 @@
     <a href="#about" class="cta">About Us</a>
   </article>
 
-  <div class="divider-2" style="background-image: url(<%= asset_url('roro-pattern.png') %>)">&nbsp;</div>
+  <div class="divider-1" style="background-image: url(<%= asset_url('roro-pattern.png') %>)">&nbsp;</div>
 
   <article id="in-person" class="welcome md:ml-10">
     <h2>Meeting in Person</h2>
@@ -62,7 +62,7 @@
     </ul>
   </article>
 
-  <div class="divider-3" style="background-image: url(<%= asset_url('roro-pattern.png') %>)">&nbsp;</div>
+  <div class="divider-2" style="background-image: url(<%= asset_url('roro-pattern.png') %>)">&nbsp;</div>
 
   <article id="online" class="welcome md:ml-10">
     <h2>Connecting Online</h2>
@@ -74,6 +74,21 @@
     <p>
       We also have talks from our previous events - both conferences and meetings - <%= link_to_external "available on YouTube", "/videos" %>. And you can <%= link_to_external "follow us on Twitter", "https://twitter.com/rubyaustralia" %>.
     </p>
+  </article>
+
+  <div class="divider-3" style="background-image: url(<%= asset_url('roro-pattern.png') %>)">&nbsp;</div>
+
+  <article id="sponsors" class="welcome md:ml-10">
+    <h2>Sponsors</h2>
+      <div class="flex flex-wrap">
+        <% sponsors.each do |sponsor| %>
+          <div class="m-6">
+              <%= link_to "/sponsors/#{sponsor['key']}" do %>
+                <%= image_tag "sponsors/#{sponsor['images'].first}", alt: sponsor['name'], style: "width: 150px" %>
+              <% end %>
+          </div>
+        <% end %>
+      </div>
   </article>
 
   <div class="divider-4" style="background-image: url(<%= asset_url('roro-pattern.png') %>)">&nbsp;</div>


### PR DESCRIPTION
Sponsor logos added to welcome/home page and link through to corresponding show pages. Makes sponsor information visible without the need to click through to "/sponsorship" page.



<img width="683" alt="image" src="https://github.com/rubyaustralia/ruby_au/assets/68765634/675c8a8f-9cb7-4db0-a18d-d09c1a8b1f7e">
