### PR TITLE
Add Victorian Business Registration Number

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,5 +1,5 @@
 <footer role="contentinfo" class="p-6">
-  <small class="">Ruby Australia website &copy; <%= Time.current.year %> Ruby Australia.<br>
+  <small class="">Ruby Australia website &copy; <%= Time.current.year %> Ruby Australia (Vic registration A0056643H).<br>
     Ruby Australia acknowledges and pays respect to the past, present and future Traditional Custodians and Elders of
     this nation and the continuation of cultural, spiritual and educational practices of Aboriginal and Torres Strait
     Islander peoples.


### PR DESCRIPTION
An incorporated association's name and registration number must appear on all notices, advertisements and business documents. Placed the registration number in the footer of the website.