### PR TITLE
Allow configurable slack id plus move slack behind auth

### DIFF
--- a/app/controllers/my/slack_invites_controller.rb
+++ b/app/controllers/my/slack_invites_controller.rb
@@ -1,7 +1,7 @@
 module My
   class SlackInvitesController < My::ApplicationController
     def show
-      redirect_to "https://join.slack.com/t/rubyau/shared_invite/zt-1pewt4vi8-TtrM~UoIJmuH9Niy0Ela6w", allow_other_host: true
+      redirect_to "https://join.slack.com/t/rubyau/shared_invite/#{ENV['SLACK_INVITE_ID']}", allow_other_host: true
     end
   end
 end

--- a/app/controllers/my/slack_invites_controller.rb
+++ b/app/controllers/my/slack_invites_controller.rb
@@ -1,0 +1,7 @@
+module My
+  class SlackInvitesController < My::ApplicationController
+    def show
+      redirect_to "https://join.slack.com/t/rubyau/shared_invite/zt-1pewt4vi8-TtrM~UoIJmuH9Niy0Ela6w", allow_other_host: true
+    end
+  end
+end

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -59,7 +59,7 @@
         <h3>Community</h3>
         <ul>
           <li><%= link_to_external "Forum (Ruby Down Under)", "https://forum.ruby.org.au/" %></li>
-          <li><%= link_to_external "Chat (Slack)", slack_path %></li>
+          <li><%= link_to_external "Chat (Slack)", my_slack_invite_path %></li>
           <li><%= link_to_external "Jobs: positions available", "https://forum.ruby.org.au/c/jobs/10", longdesc: 'Jobs posted on RubyAU Forums' %></li>
           <li><%= link_to_external "Videos", videos_path %></li>
           <li><%= link_to_external 'Mailing List', "/mailing-list" %></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
     resource :membership, only: [:destroy]
     resources :meetings, only: [:index]
     resources :access_requests, only: [:index]
+    resource :slack_invite, only: [:show]
   end
 
   resources :rsvps, only: [:show, :update, :destroy] do
@@ -38,7 +39,6 @@ Rails.application.routes.draw do
   # Off-site Redirection routes
   get '/forum', to: redirect('https://forum.ruby.org.au'), as: :forum
   get '/mailing-list', to: redirect('https://confirmsubscription.com/h/j/3DDD74A0ACC3DB22'), as: :roro_mailing_list
-  get '/slack', to: redirect('https://join.slack.com/t/rubyau/shared_invite/zt-1pewt4vi8-TtrM~UoIJmuH9Niy0Ela6w'), as: :slack
   get '/videos', to: redirect('https://www.youtube.com/@RubyAustralia'), as: :videos
   get '/merch', to: redirect('https://www.redbubble.com/people/ruby-au/explore'), as: :merch
 


### PR DESCRIPTION
This PR introduces a new ENV var that will contain the slack_invite_id that is used to allow users to sign up to the ruby au workspace.

The slack_invite ids have a certain number of uses and before this change a code change would need to be made to update the URL.

**BONUS POINTS**
A request from @quintrino was to put the slack invite link under auth so that a user must sign up as a member of Ruby Australia before they are able to gain access to the workspace.