### PR TITLE
Redirect old slack link to new slack link

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,7 @@ Rails.application.routes.draw do
   # Off-site Redirection routes
   get '/forum', to: redirect('https://forum.ruby.org.au'), as: :forum
   get '/mailing-list', to: redirect('https://confirmsubscription.com/h/j/3DDD74A0ACC3DB22'), as: :roro_mailing_list
+  get '/slack', to: redirect("/my/slack_invite")
   get '/videos', to: redirect('https://www.youtube.com/@RubyAustralia'), as: :videos
   get '/merch', to: redirect('https://www.redbubble.com/people/ruby-au/explore'), as: :merch
 


### PR DESCRIPTION
We're using a new slack link now (It's under auth) but we want the old slack link to still go somewhere.