### PR TITLE
130 - skip trigger_after_confirmation when migrating multiple emails

### DIFF
--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -1,4 +1,6 @@
 class Email < ApplicationRecord
+  attr_accessor :skip_trigger_after_confirmation
+
   belongs_to :user
 
   validates :email,
@@ -17,7 +19,7 @@ class Email < ApplicationRecord
   end
 
   def trigger_after_confirmation
-    return unless saved_change_to_confirmed_at?
+    return unless !skip_trigger_after_confirmation && saved_change_to_confirmed_at?
 
     email_update = saved_change_to_email? && email_before_last_save.present?
     user.update_mailing_list_and_memberships(email_update: email_update)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -52,7 +52,7 @@ class User < ApplicationRecord
     existing_email = read_attribute_before_type_cast('email')
     return if existing_email.blank? || email.present?
 
-    new_email = Email.new(email: existing_email, user: self, primary: true)
+    new_email = Email.new(email: existing_email, user: self, primary: true, skip_trigger_after_confirmation: true)
     new_email.skip_confirmation!
 
     if new_email.save

--- a/spec/models/email_spec.rb
+++ b/spec/models/email_spec.rb
@@ -56,4 +56,25 @@ RSpec.describe Email, type: :model do
       end
     end
   end
+
+  describe '#trigger_after_confirmation' do
+    subject(:email) { create(:email) }
+    let(:user) { email.user }
+    context 'when skip_trigger_after_confirmation is true' do
+      it 'does not call update_mailing_list_and_memberships' do
+        email.skip_trigger_after_confirmation = true
+        expect(user).not_to receive(:update_mailing_list_and_memberships)
+        email.update!(confirmed_at: Time.current)
+      end
+    end
+
+    context 'when email confirmed_at changed' do
+      subject(:email) { create(:email, confirmed_at: nil) }
+
+      it 'passes email_update: false to update_mailing_list_and_memberships' do
+        expect(user).to receive(:update_mailing_list_and_memberships).with(email_update: false)
+        email.update!(confirmed_at: Time.current)
+      end
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -84,6 +84,11 @@ RSpec.describe User, type: :model do
       )
     end
 
+    it 'does not trigger update_mailing_list_and_memberships method' do
+      expect(user_with_email_field).to_not receive(:update_mailing_list_and_memberships)
+      user_with_email_field.update_emails
+    end
+
     it 'does not create a new Email record for users with email and associated Email record' do
       user_with_emails_association
       expect { user_with_emails_association.update_emails }.not_to change(Email, :count)


### PR DESCRIPTION
Addressing issue for https://github.com/rubyaustralia/ruby_au/pull/266#issuecomment-2563660888

For existing and old emails, we do not need to trigger `update_mailing_list_and_memberships` method again