### PR TITLE
284 - import trix from cdn

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,6 +36,8 @@
   <%= csrf_meta_tags %>
   <%= vite_client_tag %>
   <%= vite_javascript_tag 'application' %>
+  <%# hack to use cdn since failed to import trix from production, no issue in dev, remove it once the issue is fixed %>
+  <%= javascript_include_tag "https://cdn.jsdelivr.net/npm/trix@2.1.12/dist/trix.umd.min.js" %>
 
 </head>
   <body class="bg-pearl">


### PR DESCRIPTION
resolve #284 

Unable to import `trix.js` in production, no issue in development, use CDN instead

run `bundle exec rails s -e production` locally to test
![image](https://github.com/user-attachments/assets/734dd6dc-a2b0-45b3-a4db-de93a077d0b7)

@leesheppard can we deploy this branch to production(do we have staging) to test?

just want to make sure the issue is resovled before merging to master

Thank you