### PR TITLE
✚ Add Assembly Four back on sponsor page

### DIFF
--- a/config/data/sponsors.yml
+++ b/config/data/sponsors.yml
@@ -6,3 +6,12 @@
   tier: Opal
   bio: |
     Bluethumb's mission is to create the world's largest online art marketplace by transforming the way art is bought and sold. We connect artists with collectors nationwide and have recently expanded our platform to the US.
+
+- name: Assembly Four
+  key: assemblyfour
+  url: https://assemblyfour.com/
+  images:
+    - 2024/assembly-four-500x143.png
+  tier: Sapphire
+  bio: |
+    [Assembly Four](https://assemblyfour.com) is a collective of sex workers and technologists on a mission to empower sex workers through technology. Sex workers are among the most marginalised, stigmatised groups in the world, and our goal is to create platforms where sex workers thrive, not just survive.


### PR DESCRIPTION
We are discussing sponsorship renewal with Assembly Four, therefore it makes sense to keep them on the website. Taking them off was an oversight.

### SCREENSHOT
![Screenshot 2025-06-04 at 4 19 52 PM](https://github.com/user-attachments/assets/8b26f107-6a00-4bc0-a930-d5fb79a87408)
