### PR TITLE
Fix circular reference in Vite/Rollup configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,7 @@ AllCops:
     - 'bin/**/*'
     - 'vendor/**/*'
     - 'node_modules/**/*'
+    - 'tmp/**/*'
   DisplayCopNames: true
   TargetRubyVersion: 3.4
   NewCops: disable

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -44,9 +44,6 @@ export default defineConfig({
     cssMinify: true,
     outDir: 'public/vite',
     rollupOptions: {
-      input: {
-        application: resolve(__dirname, 'app/frontend/entrypoints/application.js')
-      },
       external: ['jquery']
     },
     sourcemap: false,

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -10,17 +10,6 @@ export default defineConfig({
       }
     }),
   ],
-  server: {
-    host: 'localhost',
-    port: 3036,
-    strictPort: true,
-    watch: {
-      ignored: ['**/node_modules/**'],
-    },
-    headers: {
-      'Access-Control-Allow-Origin': '*',
-    },
-  },
   resolve: {
     alias: {
       '@images': resolve(__dirname, 'app/frontend/images'),

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -7,9 +7,6 @@ export default defineConfig({
     ViteRails({
       fullReload: {
         additionalPaths: ['config/routes.rb', 'app/views/**/*']
-      },
-      stimulus: {
-        hmr: true,
       }
     }),
   ],

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -38,14 +38,5 @@ export default defineConfig({
         quietDeps: true
       }
     }
-  },
-  build: {
-    minify: 'esbuild',
-    cssMinify: true,
-    outDir: 'public/vite',
-    rollupOptions: {
-      external: ['jquery']
-    },
-    sourcemap: false,
   }
 })


### PR DESCRIPTION
By referencing the `application.js` entrypoint in `build.rollupOptions.input.application`, a circular reference is created in the asset manifest generated by Vite Ruby.

Asset helper tags, e.g. `vite_image_tag`, call `ViteRuby::Manifest.path_for` to find the required asset. If the asset doesn't exist, a `ViteRuby::MissingEntrypointError` is raised and the error message includes a JSON representation of the manifest. Since the manifest hash for the asset includes an "imports" key that references the same entry in the manifest, a `JSON::NestingError` error is raised.

Annoyingly for debugging, Rollup only gets involved in production. The assets will compile, and then an exception is raised when loading a missing asset in production.

This PR also removes settings from the Vite config that I believe to be unnecessary. The explanation for each change is in the commit messages.