### PR TITLE
Remove Devise deprecation warnings

### DIFF
--- a/app/views/shared/_devise_error_alert.html.erb
+++ b/app/views/shared/_devise_error_alert.html.erb
@@ -4,7 +4,7 @@
   </div>
 <% end %>
 
-<% if devise_error_messages! %>
+<% if resource.errors.any? %>
   <div class="mt-2 text-center text-sm text-red-600">
     <%= render "devise/shared/error_messages", resource: resource %>
   </div>


### PR DESCRIPTION
`devise_error_messages!` has now been deprecated and replaced with using `resource.errors.any?` to test if errors exist, and `<%= render "devise/shared/error_messages", resource: resource %>` for rendering the errors (although that change had already been made)