### PR TITLE
Create base structure for city sites starting with Melbourne

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,4 +66,4 @@ jobs:
       - name: Run Tests
         env:
           DATABASE_URL: postgres://ruby_au:ruby_au@127.0.0.1:5432/ruby_au_test
-        run: bundle exec rspec
+        run: bundle exec rspec && bundle exec rspec sites

--- a/Gemfile
+++ b/Gemfile
@@ -85,3 +85,5 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:windows, :jruby]
+
+gem "meta-tags", "~> 2.22"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -260,6 +260,8 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.3)
+    meta-tags (2.22.1)
+      actionpack (>= 6.0.0, < 8.1)
     method_source (1.1.0)
     mini_magick (5.3.0)
       logger
@@ -577,6 +579,7 @@ DEPENDENCIES
   letter_opener
   letter_opener_web (~> 3.0)
   listen
+  meta-tags (~> 2.22)
   pg
   premailer-rails
   puma

--- a/app/frontend/entrypoints/melbourne_application.css
+++ b/app/frontend/entrypoints/melbourne_application.css
@@ -1,0 +1,1 @@
+@import "~/stylesheets/melbourne_application.scss";

--- a/app/frontend/stylesheets/melbourne_application.scss
+++ b/app/frontend/stylesheets/melbourne_application.scss
@@ -1,0 +1,20 @@
+@use "tailwindcss";
+
+:root {
+  color-scheme: light dark;
+  /*--surface: light-dark(rgb(243, 241, 253), rgb(27, 26, 34));*/
+  /*--text: light-dark(rgb(27, 26, 34), rgb(243, 241, 253));*/
+
+  --surface: light-dark(var(--color-stone-50), var(--color-stone-900));
+  --text: light-dark(var(--color-stone-900), var(--color-stone-50));
+}
+
+:where(html) {
+  background: var(--surface);
+  color: var(--text);
+}
+
+@theme {
+  --font-lekton: "Lekton", monospace;
+}
+

--- a/bin/tests
+++ b/bin/tests
@@ -5,8 +5,11 @@ set -e
 echo "[ bin/tests ] Running migrations for Test env 🚨"
 bin/rails db:migrate RAILS_ENV=test
 
-echo "[ bin/tests ] Running Rspec tests 🚨🚨"
+echo "[ bin/tests ] Running Rspec tests for Ruby AU app 🚨🚨"
 bundle exec rspec
+
+echo "[ bin/tests ] Running Rspec tests for city sites 🚨🚨"
+bundle exec rspec sites
 
 echo "[ bin/tests ] Running Rubocop 👮"
 bundle exec rubocop

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,6 +18,9 @@ require "action_view/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+# Require engines
+require_relative "../sites/melbourne/lib/melbourne"
+
 module RubyAu
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -103,4 +103,9 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   config.solid_queue.logger = ActiveSupport::Logger.new($stdout)
+
+  # TLD = 0 means Rails will assume no TLD
+  # in the url localhost:3000: domain: "localhost",tld: none
+  # in the url melbourne.localhost:3000: subdomain: "melbourne", domain: "localhost",tld: none
+  config.action_dispatch.tld_length = 0
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -91,4 +91,9 @@ Rails.application.configure do
 
   # ensure Rails is correctly serving static files in production
   config.public_file_server.enabled = true
+
+  # TLD = 2 means Rails will assume .org.au as the TLD.
+  # in the url ruby.org.au: domain: "ruby",tld: ["org", "au"]
+  # in the url melbourne.ruby.org.au: subdomain: "melbourne", domain: "ruby",tld: ["org", "au"]
+  config.action_dispatch.tld_length = 2
 end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -11,6 +11,6 @@
 # end
 
 # These inflection rules are supported but not enabled by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.acronym "RESTful"
-# end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym "LLM"
+end

--- a/config/initializers/meta_tags.rb
+++ b/config/initializers/meta_tags.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Use this setup block to configure all options available in MetaTags.
+MetaTags.configure do |config|
+  # How many characters should the title meta tag have at most. Default is 70.
+  # Set to nil or 0 to remove limits.
+  # config.title_limit = 70
+
+  # When true, site title will be truncated instead of title. Default is false.
+  # config.truncate_site_title_first = false
+
+  # Add HTML attributes to the <title> HTML tag. Default is {}.
+  # config.title_tag_attributes = {}
+
+  # Natural separator when truncating. Default is " " (space character).
+  # Set to nil to disable natural separator.
+  # This also allows you to use a whitespace regular expression (/\s/) or
+  # a Unicode space (/\p{Space}/).
+  # config.truncate_on_natural_separator = " "
+
+  # Maximum length of the page description. Default is 300.
+  # Set to nil or 0 to remove limits.
+  # config.description_limit = 300
+
+  # Maximum length of the keywords meta tag. Default is 255.
+  # config.keywords_limit = 255
+
+  # Default separator for keywords meta tag (used when an Array passed with
+  # the list of keywords). Default is ", ".
+  # config.keywords_separator = ', '
+
+  # When true, keywords will be converted to lowercase, otherwise they will
+  # appear on the page as is. Default is true.
+  # config.keywords_lowercase = true
+
+  # When true, the output will not include new line characters between meta tags.
+  # Default is false.
+  # config.minify_output = false
+
+  # When false, generated meta tags will be self-closing (<meta ... />) instead
+  # of open (`<meta ...>`). Default is true.
+  # config.open_meta_tags = true
+
+  # List of additional meta tags that should use "property" attribute instead
+  # of "name" attribute in <meta> tags.
+  # config.property_tags.push(
+  #   'x-hearthstone:deck',
+  # )
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
+  constraints subdomain: "melbourne" do
+    mount(Melbourne::Engine, at: "/")
+  end
+
   devise_for :users, controllers: {
     registrations: 'registrations',
     passwords: 'devise/passwords'

--- a/sites/melbourne/app/controllers/melbourne/application_controller.rb
+++ b/sites/melbourne/app/controllers/melbourne/application_controller.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Melbourne
+  class ApplicationController < ActionController::Base
+  end
+end

--- a/sites/melbourne/app/controllers/melbourne/events_controller.rb
+++ b/sites/melbourne/app/controllers/melbourne/events_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Melbourne
+  class EventsController < ApplicationController
+    def index
+      @events = Event.all
+    end
+
+    def show
+      @event = Event.find_by_slug(params[:slug]) # rubocop:disable Rails/DynamicFindBy
+    end
+  end
+end

--- a/sites/melbourne/app/controllers/melbourne/home_controller.rb
+++ b/sites/melbourne/app/controllers/melbourne/home_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Melbourne
+  class HomeController < ApplicationController
+    def show
+      @events = Event.all.first(3)
+    end
+  end
+end

--- a/sites/melbourne/app/models/melbourne/event.rb
+++ b/sites/melbourne/app/models/melbourne/event.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module Melbourne
+  class Event
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    attribute :uuid
+    attribute :date, :date
+    attribute :name
+    attribute :description
+    attribute :slug
+    attribute :type
+    attribute :venue
+    attribute :talks
+
+    validates :uuid, presence: true
+    validates :date, presence: true
+    validates :name, presence: true
+    validates :description, presence: true
+    validates :slug, presence: true
+    validates :type, presence: true
+    validates :venue, presence: true
+    validates :talks, presence: true
+
+    def self.all
+      @all ||= events_from_yaml_db.map do |event_data|
+        event_data = event_data.with_indifferent_access
+        Event.new(
+          **event_data.slice(:uuid, :date, :type, :description, :name, :slug),
+          venue: Venue.new(event_data.fetch("venue", {})),
+          talks: build_talks(event_data.fetch("talks", []))
+        )
+      end.sort_by(&:date).reverse!
+    end
+
+    def self.find_by_slug(slug)
+      all.find { it.slug == slug }
+    end
+
+    alias_attribute :id, :uuid
+
+    def to_param
+      slug
+    end
+
+    def schema
+      Schema.new(self).to_h
+    end
+
+    def open_graph_metadata
+      OpenGraphMetadata.new(self).to_meta_tags
+    end
+
+    def self.build_talks(talks)
+      talks.map do |talk|
+        Talk.new(
+          **talk.slice(:uuid, :title, :description, :video_url),
+          speakers: build_speakers(talk.fetch(:speakers, [])),
+        )
+      end
+    end
+
+    def self.build_speakers(speakers)
+      speakers.map { Speaker.new(**it) }
+    end
+
+    def self.events_from_yaml_db
+      YAML.load_file(Engine.root.join("db", "data", "events.yml"))
+    end
+  end
+end

--- a/sites/melbourne/app/models/melbourne/event/open_graph_metadata.rb
+++ b/sites/melbourne/app/models/melbourne/event/open_graph_metadata.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Melbourne
+  class Event
+    private_constant :OpenGraphMetadata
+    class OpenGraphMetadata
+      def initialize(event)
+        @event = event
+      end
+
+      def to_meta_tags # rubocop:disable Metrics/MethodLength
+        {
+          title: "#{event.date} - #{event.name}",
+          description: event.description,
+          keywords: "Events, Ruby, Rails, Melbourne",
+          og: {
+            title: :title,
+            description: :description,
+            image: nil,
+            url: event_url
+          },
+          twitter: {
+            card: "summary",
+            site: "@rubyau",
+            title: :title,
+            description: :description,
+          }
+        }
+      end
+
+      private
+
+      attr_reader :event
+
+      def event_url = ::Melbourne::Engine.routes.url_helpers.event_url(event)
+    end
+  end
+end

--- a/sites/melbourne/app/models/melbourne/event/schema.rb
+++ b/sites/melbourne/app/models/melbourne/event/schema.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# https://developers.google.com/search/docs/appearance/structured-data/event
+module Melbourne
+  class Event
+    private_constant :Schema
+    class Schema
+      TYPE = "Event"
+
+      def initialize(event)
+        @event = event
+      end
+
+      def to_h # rubocop:disable Metrics/MethodLength
+        {
+          "@context" => "https://schema.org",
+          "@type" => TYPE,
+          name: event.name,
+          start_date:,
+          end_date:,
+          event_status: "https://schema.org/EventScheduled",
+          location: event.venue.schema,
+          description: event.description,
+          performers: event.talks.flat_map(&:speakers).flat_map { it.schema.to_h }
+        }
+      end
+
+      private
+
+      attr_reader :event
+
+      def event_url = ::Melbourne::Engine.routes.url_helpers.event_url(event)
+
+      # Start date in ISO8601 format. The date should include the time and the timezone.
+      # As of 2025-07-17 the time zone is set up to Australia/Melbourne in config/application.rb:49.
+      # This might create problems in the future with meetups in other locations.
+      # https://developers.google.com/search/docs/appearance/structured-data/event#date-time-best-guidelines
+      def start_date = Time.new(event.date.year, event.date.month, event.date.day, 18).iso8601
+
+      # Start date in ISO8601 format. The date should include the time and the timezone.
+      # As of 2025-07-17 the time zone is set up to Australia/Melbourne in config/application.rb:49.
+      # This might create problems in the future with meetups in other locations.
+      # https://developers.google.com/search/docs/appearance/structured-data/event#date-time-best-guidelines
+      def end_date = Time.new(event.date.year, event.date.month, event.date.day, 20, 30).iso8601
+    end
+  end
+end

--- a/sites/melbourne/app/models/melbourne/event/speaker.rb
+++ b/sites/melbourne/app/models/melbourne/event/speaker.rb
@@ -1,0 +1,18 @@
+module Melbourne
+  class Event
+    class Speaker
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      attribute :name, default: "unknown"
+      attribute :contact_details, default: {}
+
+      validates :name, presence: true
+      validates :contact_details, presence: true
+
+      def schema
+        Schema.new(self).to_h
+      end
+    end
+  end
+end

--- a/sites/melbourne/app/models/melbourne/event/speaker/schema.rb
+++ b/sites/melbourne/app/models/melbourne/event/speaker/schema.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# https://developers.google.com/search/docs/appearance/structured-data/event#structured-data-type-definitions
+# https://schema.org/Person
+module Melbourne
+  class Event
+    class Speaker
+      class Schema
+        TYPE = "Person"
+
+        def initialize(speaker)
+          @speaker = speaker
+        end
+
+        def to_h
+          {
+            "@type" => TYPE,
+            name: speaker.name,
+          }
+        end
+
+        private
+
+        attr_reader :speaker
+      end
+    end
+  end
+end

--- a/sites/melbourne/app/models/melbourne/event/talk.rb
+++ b/sites/melbourne/app/models/melbourne/event/talk.rb
@@ -1,0 +1,20 @@
+module Melbourne
+  class Event
+    class Talk
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      attribute :uuid
+      attribute :title
+      attribute :description
+      attribute :video_url, default: "unknown"
+      attribute :speakers, default: []
+
+      validates :uuid, presence: true
+      validates :title, presence: true
+      validates :description, presence: true
+      validates :video_url, presence: true
+      validates :speakers, presence: true
+    end
+  end
+end

--- a/sites/melbourne/app/models/melbourne/event/venue.rb
+++ b/sites/melbourne/app/models/melbourne/event/venue.rb
@@ -1,0 +1,20 @@
+module Melbourne
+  class Event
+    class Venue
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      attribute :name
+      attribute :google_maps_url
+      attribute :address, default: {}
+
+      validates :name, presence: true
+      validates :google_maps_url, presence: true
+      validates :address, presence: true
+
+      def schema
+        Schema.new(self).to_h
+      end
+    end
+  end
+end

--- a/sites/melbourne/app/models/melbourne/event/venue/schema.rb
+++ b/sites/melbourne/app/models/melbourne/event/venue/schema.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# https://developers.google.com/search/docs/appearance/structured-data/event#structured-data-type-definitions
+# https://schema.org/PostalAddress
+module Melbourne
+  class Event
+    class Venue
+      class Schema
+        TYPE = "Place"
+
+        def initialize(venue)
+          @venue = venue
+        end
+
+        def to_h # rubocop:disable Metrics/MethodLength
+          {
+            "@type" => TYPE,
+            name: venue.name,
+            address: {
+              "@type" => "PostalAddress",
+              street_address: venue.address.fetch(:street),
+              address_locality: venue.address.fetch(:locality),
+              postal_code: venue.address.fetch(:postal_code),
+              address_region: venue.address.fetch(:region),
+              address_country: venue.address.fetch(:country)
+            }
+          }
+        end
+
+        private
+
+        attr_reader :venue
+      end
+    end
+  end
+end

--- a/sites/melbourne/app/views/layouts/melbourne/application.html.erb
+++ b/sites/melbourne/app/views/layouts/melbourne/application.html.erb
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <%= display_meta_tags site: "Ruby Melbourne" %>
+  <%= yield :head %>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Lekton:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+
+  <%= vite_stylesheet_tag("melbourne_application") %>
+</head>
+<body>
+<%= yield %>
+</body>
+</html>

--- a/sites/melbourne/app/views/melbourne/events/_event.html.erb
+++ b/sites/melbourne/app/views/melbourne/events/_event.html.erb
@@ -1,0 +1,10 @@
+<%= tag.section id: dom_id(event) do %>
+  <p><%= event.date %></p>
+  <p><%= event.summary %></p>
+  <%= link_to "see event", event_path(event.slug) %>
+  <p>
+    <%= link_to event.venue.google_maps_url, class: "underline" do %>
+      <%= event.venue.name %>
+    <% end %>
+  </p>
+<% end %>

--- a/sites/melbourne/app/views/melbourne/events/index.html.erb
+++ b/sites/melbourne/app/views/melbourne/events/index.html.erb
@@ -1,0 +1,9 @@
+<% set_meta_tags title: "Events",
+                 description: "All past Ruby Australia events with talks, videos and short summaries",
+                 keywords: "Events" %>
+
+<div class="container mx-auto">
+  <div class="space-y-4">
+    <%= render @events %>
+  </div>
+</div>

--- a/sites/melbourne/app/views/melbourne/events/show.html.erb
+++ b/sites/melbourne/app/views/melbourne/events/show.html.erb
@@ -5,7 +5,7 @@
   </script>
 <% end %>
 <div class="container mx-auto">
-  <h1></h1>
+  <h1><%= @event.name %></h1>
 
   <h2 class="text-2xl">Talks</h2>
   <div class="mt-8">
@@ -26,4 +26,3 @@
     <% end %>
   </div>
 </div>
-<% console %>

--- a/sites/melbourne/app/views/melbourne/events/show.html.erb
+++ b/sites/melbourne/app/views/melbourne/events/show.html.erb
@@ -1,0 +1,29 @@
+<% set_meta_tags @event.open_graph_metadata %>
+<% content_for :head do  %>
+  <script type="application/ld+json">
+    <%= raw JSON.pretty_generate @event.schema %>
+  </script>
+<% end %>
+<div class="container mx-auto">
+  <h1></h1>
+
+  <h2 class="text-2xl">Talks</h2>
+  <div class="mt-8">
+    <% @event.talks.each do |talk| %>
+      <article>
+        <p>
+          <%= talk.description %>
+        </p>
+        <ul>
+          <% talk.speakers.each do |speaker| %>
+            <li>
+              <p><%= speaker.name %></p>
+              <p><%= speaker.contact_details %></p>
+            </li>
+          <% end %>
+        </ul>
+      </article>
+    <% end %>
+  </div>
+</div>
+<% console %>

--- a/sites/melbourne/app/views/melbourne/home/show.html.erb
+++ b/sites/melbourne/app/views/melbourne/home/show.html.erb
@@ -1,0 +1,56 @@
+<div class="h-lvh overflow-hidden overflow-y-scroll">
+  <div class="font-mono text-right text-xs p-2 text-stone-500">Ruby Melbourne is a
+    <a href="https://ruby.org.au" class="underline" target="_blank">Ruby Australia Meetup</a></div>
+  <div class="grid md:place-items-center">
+    <div class="block md:flex w-full h-[calc(100lvh-2rem)] overflow-hidden">
+      <div class="w-full md:max-w-1/2 h-[50vh] md:h-full md:block overflow-hidden">
+        <div aria-hidden="true"
+             class="break-all text-7xl md:text-[7rem] lg:text-[10rem] tracking-widest font-lekton italic overflow-hidden text-stone-200 dark:text-stone-800">
+          <span class="text-yellow-600 dark:text-yellow-400">RUBY</span>MELBOURNERUBY<span class="text-yellow-600 dark:text-yellow-400">MELBOURNE</span>RUBY<span>MELBOURNE</span>RUBYMELBOURNERUBYMELBOURNERUBYMELBOURNERUBYMELBOURNERUBYMELBOURNERUBYMELBOURNERUBYMELBOURNERUBYMELBOURNERUBYMELBOURNERUBYMELBOURNE
+        </div>
+      </div>
+      <div class="w-full md:w-1/2">
+        <div class="h-full grid items-center p-4">
+          <div class="font-lekton text-2xl">
+            <div class="font-bold"><h1 class="inline">Ruby Melbourne</h1>
+              <p class="inline">Meetup Relaunch</p></div>
+            <div class="flex gap-4 items-center mt-8">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
+                   stroke="currentColor"
+                   class="size-6">
+                <path stroke-linecap="round" stroke-linejoin="round"
+                      d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5"/>
+              </svg>
+              <p>31 July 2025</p>
+            </div>
+            <div class="flex gap-4 mt-2 items-center">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
+                   stroke="currentColor" class="size-6">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"/>
+                <path stroke-linecap="round" stroke-linejoin="round"
+                      d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1 1 15 0Z"/>
+              </svg>
+              <div>
+                <p>Location: Ferocia ⚡️</p>
+                <div>
+                  <a href="https://maps.app.goo.gl/9xvvwpdw9BkByKqy9" target="_blank">
+                    <span class="underline">Level 7/271 Collins St, Melbourne VIC 3000</span>
+                  </a>
+                </div>
+              </div>
+            </div>
+            <div class="flex gap-4 mt-2 items-center">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
+                   stroke="currentColor" class="size-6">
+                <path stroke-linecap="round" stroke-linejoin="round"
+                      d="M16.5 6v.75m0 3v.75m0 3v.75m0 3V18m-9-5.25h5.25M7.5 15h3M3.375 5.25c-.621 0-1.125.504-1.125 1.125v3.026a2.999 2.999 0 0 1 0 5.198v3.026c0 .621.504 1.125 1.125 1.125h17.25c.621 0 1.125-.504 1.125-1.125v-3.026a2.999 2.999 0 0 1 0-5.198V6.375c0-.621-.504-1.125-1.125-1.125H3.375Z"/>
+              </svg>
+              <a href="https://www.meetup.com/ruby-on-rails-oceania-melbourne/events/305601915" target="_blank"
+                 class="underline">RSVP Today</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/sites/melbourne/config/routes.rb
+++ b/sites/melbourne/config/routes.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Melbourne::Engine.routes.draw do
+  root to: "home#show"
+  resources :events, only: %i[index show], param: :slug
+end

--- a/sites/melbourne/db/data/events.yml
+++ b/sites/melbourne/db/data/events.yml
@@ -1,0 +1,1137 @@
+---
+- uuid: 4438e22b-055c-4f37-b2c8-2eb7bd236296
+  date: '2025-06-26'
+  name: Communicating Intent in Code with HashNotAdam
+  description: HashNotAdam guides us through the art of writing code that speaks your
+    intent and avoids common pitfalls, drawing from real Rails experience.
+  slug: 2025-06-26-communicating-intent-in-code-hashnotadam
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+    - uuid: bb5302de-44bd-4086-8ae4-556a2bc7cb15
+      title: 'The Unspoken Contract: Communicating Intent Through Code'
+      description: Discover the secrets of writing code that communicates your intent!
+        Learn from a real Rails bug why naming, structure, and clear boundaries matter.
+        Ideal for devs who want their code to speak—loud and clear. Join HashNotAdam
+        for practical tips and relatable war stories!
+      video_url: TODO
+      speakers:
+        - name: HashNotAdam
+          contact_details:
+            github_username: HashNotAdam
+            x_handle:
+            linkedin_handle: HashNotAdam
+            bluesky_handle:
+            mastodon_handle:
+            website:
+- uuid: 1693724f-2cf7-462a-8e92-95183f80d7c4
+  date: '2025-04-24'
+  name: Task Runners with Michael Milewski & Rails 8 with John Sherwood
+  description: Explore task runners with Michael Milewski, then get hands-on with
+    Rails 8 in production with John Sherwood! Two practical talks to supercharge your
+    dev workflow.
+  slug: 2025-04-24-task-runners-and-rails-8
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+    - uuid: 1c98f653-d880-4097-8cd3-8cd1838ab7a5
+      title: Make vs Justfile vs Mise
+      description: Choosing the perfect task runner? Michael Milewski breaks down Make,
+        Justfile, Mise, and more. Discover best practices, playbooks, and how far Developer
+        Infrastructure as Code can go. Don’t miss this practical, energetic tour of
+        modern task runners!
+      video_url: TODO
+      speakers:
+        - name: Michael Milewski
+          contact_details:
+            github_username: saramic
+            x_handle: saramic
+            linkedin_handle: michael-milewski
+            bluesky_handle:
+            mastodon_handle:
+            website: https://sessionize.com/michael-milewski/
+    - uuid: e8b99459-680e-4e37-965f-8a6b1d180ee4
+      title: rails 8 new
+      description: Join John Sherwood as he shares lessons from building a production
+        app on Rails 8! Learn the ins, outs, and happy surprises of Rails 8 with Kamal,
+        Action Cable, Active Job, and more. Bring your questions—it’s interactive and
+        fun!
+      video_url: TODO
+      speakers:
+        - name: John Sherwood
+          contact_details:
+            github_username: ponny
+            x_handle: ponny
+            linkedin_handle: johnsherwooddeveloper
+            bluesky_handle: ponny.dev
+            mastodon_handle:
+            website:
+- uuid: 3e09ed96-cbb6-4089-83d1-baa3930d5dff
+  date: '2025-05-29'
+  name: Mastering Turbo Forms with Matt Hood and SQLite in Ruby with Simon Hildebrandt
+  description: Join Matt Hood as he unravels Turbo form wizardry and Simon Hildebrandt
+    delves into using SQLite as a Ruby gem. Insightful, interactive, and fun!
+  slug: 2025-05-29-turbo-forms-sqlite-gem
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+    - uuid: 80671f1f-3790-448b-bdcd-fae31f033d31
+      title: How on earth do you manage forms with Turbo?
+      description: "Get the inside scoop on taming tricky Turbo forms! Matt Hood shares
+      hands-on tips and fun tricks for error handling, validation, and making forms
+      a breeze. Perfect for anyone wanting smoother Rails forms. \U0001F680"
+      video_url: TODO
+      speakers:
+        - name: Matt Hood
+          contact_details:
+            github_username: MattHood
+            x_handle:
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle:
+            website:
+    - uuid: 405f23a5-d49c-4e14-819e-385472aa55df
+      title: SQLite-ruby - a whole SQL database in a gem
+      description: Discover the wonders of SQLite wrapped neatly in a Ruby gem! Simon
+        Hildebrandt introduces SQLite-ruby—fast, familiar, and a little bit magical.
+        Bring your questions and curiosity!
+      video_url: TODO
+      speakers:
+        - name: Simon Hildebrandt
+          contact_details:
+            github_username: simonhildebrandt
+            x_handle:
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle: "@apocraphilia@hachyderm.io"
+            website:
+- uuid: 5722c07e-31d3-4dbc-bee2-c833f400b6fc
+  date: '2025-03-27'
+  name: Business Logic Objects Panel & Rack Fundamentals with Julian, Adam, Simon
+  description: Dive into advanced Ruby business logic structures in a lively panel
+    with Julian Pinzon and Adam, then get hands-on with Rack’s fundamentals with Simon
+    Hildebrandt.
+  slug: 2025-03-27-logic-objects-and-rack-fundamentals
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+    - uuid: a82bd5c2-ea5c-48e3-8b3e-f12c88fcc403
+      title: Panel/Discussion/Riffing Session on Objects to encapsulate business logic
+      description: Join Julian Pinzon and Adam for a lively panel on modern ways to
+        organize business logic in Ruby apps. Discover practical tips, fresh perspectives,
+        and get your questions answered. Don't miss this spirited session full of insight
+        and laughs!
+      video_url: TODO
+      speakers:
+        - name: Julian Pinzon
+          contact_details:
+            github_username: pinzonjulian
+            x_handle:
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle:
+            website:
+        - name: Adam
+          contact_details:
+            github_username: HashNotAdam
+            x_handle:
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle:
+            website:
+    - uuid: 355ec943-1aa3-478f-96f6-9148e7010cdd
+      title: Rack Fundamentals revisited
+      description: Simon Hildebrandt revisits the Rack layer under Ruby’s most popular
+        web frameworks. Learn the core mechanics and find out when you don’t need Rails!
+        Perfect for Rubyists looking to level-up their backend game.
+      video_url: TODO
+      speakers:
+        - name: Simon Hildebrandt
+          contact_details:
+            github_username: simonhildebrandt
+            x_handle:
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle: "@apocraphilia@hachyderm.io"
+            website:
+- uuid: 405f46ee-f5c5-4793-90d8-33673a903328
+  date: '2025-02-27'
+  name: Semantic Search and RAG with Ruby by Daniel Kaminsky
+  description: Explore smart search systems in Ruby! Daniel Kaminsky breaks down embeddings,
+    RAG, and more.
+  slug: 2025-02-27-semantic-search-rag-ruby
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+    - uuid: 24e8c8cb-ec66-45f1-be2a-06da1f1e11b3
+      title: Semantic Search and RAG with Ruby
+      description: Curious about modern smart search? Join us as Daniel Kaminsky walks
+        through building a powerful semantic search system with Ruby, from embeddings
+        to Retrieval Augmented Generation. Perfect for those interested in the cutting
+        edge of search tech!
+      video_url: TODO
+      speakers:
+        - name: Daniel Kaminsky
+          contact_details:
+            github_username: dkam
+            x_handle:
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle: "@dkam@ruby.social"
+            website:
+- uuid: '050789d7-68cf-4c77-8155-44e670e7a7ac'
+  date: '2025-01-30'
+  name: Puma Internals with Joshua and Ruby 3.4/Rails 8 Salad by Anton
+  description: Explore Puma’s secrets with Joshua and get the tasty highlights of
+    Ruby 3.4 & Rails 8 with Anton.
+  slug: 2025-01-30-puma-ruby-salad
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+    - uuid: '0490599c-9a1c-4bdd-940e-8314c4605a16'
+      title: The Inner Workings of Puma
+      description: Ever wondered what makes Puma tick? Joshua Yeo guides us deep inside
+        Puma’s design and advanced features. Ideal for Rubyists who want to level up
+        their server game and understand performance secrets up close!
+      video_url: TODO
+      speakers:
+        - name: Joshua Yeo
+          contact_details:
+            github_username:
+            x_handle:
+            linkedin_handle:
+            bluesky_handle: joshuay03.bsky.social
+            mastodon_handle: "@joshuay03@ruby.social"
+            website:
+    - uuid: ddf7ad60-0c0f-4aa8-a55e-6ebf4249fa19
+      title: Ruby salad. What's fresh on the market?
+      description: Join Anton for a flavourful tour of Ruby 3.4 and Rails 8’s freshest
+        features! If you love seeing new ruby and rails goodness in action—including
+        authentication generators and Rodauth vs Rails Auth—don’t miss this bite-sized
+        update.
+      video_url: TODO
+      speakers:
+        - name: Anton Tolik
+          contact_details:
+            github_username:
+            x_handle:
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle:
+            website:
+- uuid: 72262239-7a6b-4f1f-a87c-8fbd9605b578
+  date: '2024-10-24'
+  name: Cursor v Copilot with Ceels & Happy Ruby SAML by Pat
+  description: Join us for an AI coding showdown with Ceels and dive into practical
+    SAML magic for Ruby with Pat!
+  slug: 2024-10-24-cursor-v-copilot-and-happy-ruby-saml
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+    - uuid: ff613e61-e172-4488-b858-bc97899918ea
+      title: 'Cursor v Github Copilot: building a better data schema tool?'
+      description: Ceels puts Cursor and Copilot head to head! Get tips for setting
+        up Cursor, explore its AI model options, and discover which tool fits your workflow
+        best. Bring your questions and see these coding copilots in action!
+      video_url: TODO
+      speakers:
+        - name: Ceels
+          contact_details:
+            github_username:
+            x_handle:
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle: "@ceels"
+            website:
+    - uuid: 8aa4db42-4d3e-4bb2-bde4-5710cf269264
+      title: Happy Ruby SAML Development
+      description: Pat guides you through tackling real-world SAML authentication in
+        Ruby—no mocking, just hands-on SSO, fast Nokogiri parsing, and multi-domain
+        setups the Covidence way. Learn how to smooth out your SAML experience!
+      video_url: TODO
+      speakers:
+        - name: Pat
+          contact_details:
+            github_username: pat
+            x_handle:
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle: "@pat@hachyderm.io"
+            website:
+- uuid: e9e7267b-cf7b-4611-88ce-14718b5d8225
+  date: '2024-11-28'
+  name: Hotwire Happiness with Jero Paul & Rails CurrentAttributes with Darkfishy
+  description: Dive into frontend joy with Jero Paul on Hotwire, Turbo & Stimulus.
+    Then, uncover the magic of Rails `CurrentAttributes` with Darkfishy.
+  slug: 2024-11-28-hotwire-and-currentattributes
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+    - uuid: 0c5391de-34aa-40d5-ab76-617624494507
+      title: Turbo (Hotwire), Stimulusjs and being happy with front end development
+        again
+      description: "Rediscover the joy of frontend dev! Jero Paul shares his Hotwire,
+      Turbo, and Stimulus journey—great for anyone ready to love building apps again
+      \U0001F680. Come see why modern Rails tools spark happiness!"
+      video_url: TODO
+      speakers:
+        - name: Jero Paul
+          contact_details:
+            github_username: jeropaul
+            x_handle: gardengnome_au
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle:
+            website:
+    - uuid: 51db52cf-ce23-4d9b-bbb4-179cecf0bf16
+      title: How do `CurrentAttributes` work?
+      description: Ever wondered how Rails keeps track of values per request? Darkfishy
+        explains `ActiveSupport::CurrentAttributes`, request isolation, and more in
+        an engaging and practical talk. Perfect for Rails developers seeking backend
+        clarity!
+      video_url: TODO
+      speakers:
+        - name: Darkfishy
+          contact_details:
+            github_username: darkfishy
+            x_handle:
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle:
+            website:
+- uuid: b02f51ea-7d82-4bc7-b5c9-764c0baabdfd
+  date: '2024-09-26'
+  name: Understanding reload! in Rails with Darkfishy & Oaken Seeds by Julian Pinzon
+  description: Discover the magic behind Rails' reload! with Darkfishy and get a fresh
+    take on seeds and fixtures with Julian Pinzon.
+  slug: 2024-09-26-reload-rails-oaken-seeds
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+    - uuid: 32c4cdac-7c77-4472-9edc-72e5fffd795e
+      title: How does `reload!` work?
+      description: Curious about what happens when you hit `reload!` in the Rails console?
+        Join Darkfishy as we peek under the hood and reveal how Rails reloads code,
+        what classes are affected, and the impacts on your dev workflow. Rails magic,
+        demystified!
+      video_url: TODO
+      speakers:
+        - name: darkfishy
+          contact_details:
+            github_username: darkfishy
+            x_handle: fusionfish
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle:
+            website:
+    - uuid: 0722f794-032d-4646-8114-8004546d1996
+      title: Oaken - A fresh take on seeds and fixtures
+      description: Step up your data game! Join Julian Pinzon as he explores Oaken,
+        a new way to handle seeds and fixtures in Rails. Discover efficient methods,
+        best practices, and why Oaken could become your go-to for dev data. Fresh ideas
+        guaranteed!
+      video_url: TODO
+      speakers:
+        - name: Julian Pinzon
+          contact_details:
+            github_username: pinzonjulian
+            x_handle: pinzonjulian
+            linkedin_handle: pinzonjulian
+            bluesky_handle: pinzonjulian
+            mastodon_handle: pinzonjulian
+            website:
+- uuid: a166fb19-330b-4735-bce1-5d5e9cb5ccad
+  date: '2024-08-29'
+  name: Career Change Inspiration with Helen Stonehouse & Rails Engines with Chris
+    Oliver
+  description: Hear Helen Stonehouse’s journey into tech and get hands-on with Rails
+    Engines in a fun double bill with Chris Oliver.
+  slug: 2024-08-29-career-change-rails-engines
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+    - uuid: bb6151cd-90f6-417d-b2e5-39e0ae0a18d6
+      title: My Career Change - Nothing is what it seems
+      description: Helen Stonehouse shares her inspiring journey into tech, filled with
+        relatable anecdotes and encouragement to take the leap. Perfect for anyone pondering
+        a career shift or just looking for a dose of motivation!
+      video_url: TODO
+      speakers:
+        - name: Helen Stonehouse
+          contact_details:
+            github_username:
+            x_handle: cinnamonbabies
+            linkedin_handle: helen-stonehouse
+            bluesky_handle:
+            mastodon_handle:
+            website:
+    - uuid: e3aa5ff9-41f6-4652-b090-e55f29d7186a
+      title: Rails Engines in 20 minutes
+      description: Curious how to extend Rails? Chris Oliver will walk you through building
+        plugins and using Engines. Join us for a practical, speedy deep dive—perfect
+        for devs wanting to level up their Rails skills!
+      video_url: TODO
+      speakers:
+        - name: Chris Oliver
+          contact_details:
+            github_username: excid3
+            x_handle:
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle:
+            website:
+- uuid: 7a39e549-cf0d-402f-81f9-52e2593907cc
+  date: '2024-07-25'
+  name: Pinkest Pink with Dan Laush & Allyship with Nick Wolf
+  description: Dive into vibrant web colors with Dan Laush and learn about being a
+    good male ally with Nick Wolf.
+  slug: 2024-07-25-pinkest-pink-and-being-a-good-male-ally
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+    - uuid: a85a558d-af6c-4bc9-8d87-99cc13206869
+      title: Pinkest Pink
+      description: Explore the web’s newest, brightest colors! Dan Laush shares how
+        our eyes see color and how we recreate vibrant realities on screens. Join us
+        for a colorful and fun talk that will make you see web colors in a whole new
+        light!
+      video_url: TODO
+      speakers:
+        - name: Dan Laush
+          contact_details:
+            github_username: danlaush
+            x_handle:
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle:
+            website: https://danlaush.biz/
+    - uuid: 75c3ba72-bd69-4d30-a4a1-da1a4cc30a06
+      title: Being a Good Male Ally
+      description: Nick Wolf guides us through what it means to be a supportive male
+        ally. Join his insightful talk and foster a more inclusive, positive environment
+        for everyone. Practical tips and genuine stories included!
+      video_url: TODO
+      speakers:
+        - name: Nick Wolf
+          contact_details:
+            github_username: quintrino
+            x_handle:
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle:
+            website: https://nickwolf.com.au
+- uuid: 02364aaf-c011-4115-afde-66571500a38e
+  date: '2024-06-27'
+  name: Rebuilding Products with Prakriti Mateti & Turbo in Laravel with Simran Sawhney
+  description: Join Prakriti Mateti as she shares insights on rebuilding a large product
+    from scratch, plus discover Turbo in Laravel with Simran Sawhney.
+  slug: 2024-06-27-rebuilding-products-and-turbo-in-laravel
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+    - uuid: 63f64bd1-38f3-488a-ad50-8fa1e0af6b85
+      title: One does not simply... rebuild a product
+      description: "Thinking of rebuilding a big product? Join Prakriti Mateti as she
+      takes you through the highs, lows, and lessons of rebuilding Culture Amp's second
+      biggest platform! Great for anyone facing tough legacy code and tech debt. \U0001F370"
+      video_url: TODO
+      speakers:
+        - name: Prakriti Mateti
+          contact_details:
+            github_username:
+            x_handle:
+            linkedin_handle: prakritimateti
+            bluesky_handle:
+            mastodon_handle:
+            website:
+    - uuid: d1fe4bdb-b476-499e-8c07-94a08324587f
+      title: Laravel, meet my friend Turbo
+      description: Simran Sawhney shows how Turbo can spice up your Laravel projects!
+        Get the scoop on Turbo, Turbo Native, and Strada, and see how they compare with
+        Livewire. Perfect for Rubyists curious about the PHP world!
+      video_url: TODO
+      speakers:
+        - name: Simran Sawhney
+          contact_details:
+            github_username: simran-sawhney
+            x_handle:
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle:
+            website:
+- uuid: d26df2c6-0a42-46e4-ab08-ae7308961af2
+  date: '2024-05-30'
+  name: 'Understanding Cursors: Modern Pagination Approaches in Ruby'
+  description: Explore why cursor-based pagination trumps traditional pagination in
+    Ruby—staving off data staleness and powering GraphQL and more. Perfect for anyone
+    moving beyond standard page-by-page queries!
+  slug: 2024-05-30-cursors-modern-pagination-ruby
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+    - uuid: 74233503-7e5c-424b-8767-ffffadff751f
+      title: 'Cursors: Why Pagination is Bad-gination!'
+      description: Don't let your data get stale! Dive into modern cursor-based pagination
+        with Ruby and see why it's taking over GraphQL and beyond. You'll learn new
+        ways to keep your info fresh, fast, and reliable. Pagination will never look
+        the same again! ⚡
+      video_url: TODO
+      speakers:
+        - name: Simon Hildebrandt
+          contact_details:
+            github_username: simonhildebrandt
+            x_handle:
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle:
+            website:
+- uuid: 3ed4e019-6bcc-4940-866b-d94d597e79c2
+  date: '2024-04-25'
+  name: Dissecting Rails with Anthony Chen
+  description: Join Anthony Chen as he shares his dive into Rails internals—Active
+    Support, Active Model, and more—from his learning journey. Perfect for curious
+    Rubyists!
+  slug: 2024-04-25-dissecting-rails
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+    - uuid: 809987eb-6e08-4dec-b4ed-ef10560ffc24
+      title: Dissecting Rails
+      description: "Explore Anthony Chen's hands-on takeaways from dissecting Rails
+      internals! Learn about Active Support, Active Model, and get insights to fuel
+      your Rails journey. Great for learners and fans of Ruby alike! \U0001F680"
+      video_url: TODO
+      speakers:
+        - name: Anthony Chen
+          contact_details:
+            github_username: friendlyantz
+            x_handle: friendlyantz
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle:
+            website:
+- uuid: d68fc115-ac10-4e82-a772-8d59a31bf6ed
+  date: '2024-03-28'
+  name: One Billion Rows in Ruby with Rian McGuire & Ruby Economics by Ponny
+  description: Explore CPU crunching in Ruby with Rian McGuire and discover the economics
+    behind the Ruby ecosystem with Ponny. Insights, techniques, and fun for every
+    Rubyist!
+  slug: 2024-03-28-one-billion-rows-and-ruby-economics
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+    - uuid: 70a56346-06f3-4452-bc29-1d35c69a5cb5
+      title: One Billion Rows in Ruby
+      description: Find out if Ruby can tackle serious data crunching! Rian McGuire
+        dives into the One Billion Row Challenge, optimizing Ruby to the max. Perfect
+        for anyone who wants to push Ruby’s limits. Don’t miss this adventure in code
+        and speed!
+      video_url: TODO
+      speakers:
+        - name: Rian McGuire
+          contact_details:
+            github_username: rianmcguire
+            x_handle:
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle:
+            website:
+    - uuid: c04298ec-43c5-4c0c-80a6-696de64fd90b
+      title: The Economics of Ruby
+      description: Ruby plus economics—what's not to love? Ponny gives a rapid-fire
+        talk on the flow of resources, incentives, and the unsung heroes powering the
+        Ruby world. Get a fresh perspective on what keeps our community ticking!
+      video_url: TODO
+      speakers:
+        - name: Ponny
+          contact_details:
+            github_username: ponny
+            x_handle: ponny
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle:
+            website:
+- uuid: 85a493b8-b676-4677-9ba2-83d6b3125d34
+  date: '2024-02-22'
+  name: Self-hosting Rails with Saramic & Scaling Systems with Stefanus Wilfrid
+  description: Explore how to host a Rails app from home with Saramic and master scaling
+    basics of distributed systems with Stefanus Wilfrid.
+  slug: 2024-02-22-self-hosting-and-scaling-rails
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+    - uuid: f3ec845d-30ba-45f0-a7a8-ec1273301581
+      title: Can I host a rails app from a home server?
+      description: "Curious about running Rails from your own home? Saramic explores
+      self-hosting, cost savings, DevOps fun, and why DIY deployment rocks. Come see
+      how far you can go with bare metal! \U0001F4BB"
+      video_url: TODO
+      speakers:
+        - name: Saramic
+          contact_details:
+            github_username: saramic
+            x_handle:
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle:
+            website:
+    - uuid: ae006d1e-0d6d-4980-a665-98dcac1231b9
+      title: System Design & Distributed System Lightweight Concept
+      description: "Join Stefanus Wilfrid for a practical session on scaling your app!
+      Learn lightweight strategies for vertical/horizontal scaling and get hands-on
+      tips for taming distributed systems. \U0001F680"
+      video_url: TODO
+      speakers:
+        - name: Stefanus Wilfrid
+          contact_details:
+            github_username: Stefanuswilfrid
+            x_handle:
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle:
+            website:
+- uuid: 3f4bc51c-83c0-43f8-a1a9-6991c46ade42
+  date: '2024-01-25'
+  name: DMARC Reports with HashNotAdam & Ruby Fibers with KJ Tsanaktsidis
+  description: Discover how to process DMARC reports with Action Mailbox, then take
+    a deep dive into the internals of Ruby fibers with KJ!
+  slug: 2024-01-25-dmarc-action-mailbox-and-ruby-fibers
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+    - uuid: 15d1e458-5652-4687-9a79-ba151f23edbf
+      title: Processing DMARC reports via Action Mailbox
+      description: Curious about DMARC reports? See how HashNotAdam automates parsing
+        and alerts with Action Mailbox! Perfect if you want less spam and clearer email
+        deliverability insights—all using Ruby on Rails. Join us for email geekery made
+        simple and fun!
+      video_url: TODO
+      speakers:
+        - name: HashNotAdam
+          contact_details:
+            github_username: HashNotAdam
+            x_handle:
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle:
+            website:
+    - uuid: 95efaac2-63ed-4c32-9ef7-1f3192b3d08f
+      title: Something Something Fibers Something
+      description: Dive into Ruby's fiber internals with KJ Tsanaktsidis! Unpack how
+        Fiber.yield and resume work, how fibers relate to threads, and discover their
+        awesome low-level magic. Perfect for Rubyists who love digging into the guts
+        of the language!
+      video_url: TODO
+      speakers:
+        - name: KJ Tsanaktsidis
+          contact_details:
+            github_username: KJTsanaktsidis
+            x_handle:
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle:
+            website:
+- uuid: e0a01976-53d5-47bc-9ea5-0312dd22abdb
+  date: '2023-11-23'
+  name: Developer Wisdom with Justin Towsey & Rails Engines Discussion with Anton
+    Valkov
+  description: Join Justin Towsey for lessons and wisdom from a year as a dev, then
+    dive into Rails architecture and engines with Anton Valkov in a panel-style discussion.
+  slug: 2023-11-23-developer-wisdom-rails-engines
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+    - uuid: b3040034-49a1-4d9d-91a3-8fe8a94a8382
+      title: Precious gems I've learned during my first dev year
+      description: Reflect on a year packed with developer discoveries! Justin shares
+        his top nuggets of wisdom and inspiring moments from his first year in tech.
+        Perfect for new and seasoned devs alike to learn, laugh, and relate.
+      video_url: TODO
+      speakers:
+        - name: Justin Towsey
+          contact_details:
+            github_username: j-tws
+            x_handle:
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle:
+            website:
+    - uuid: 3fc6804f-545d-4548-9e05-569197774b81
+      title: Rails architecture with engines work group
+      description: Explore the power of Rails Engines! Anton will demo his app and kick
+        off a group discussion on architecture best practices, sharing stories and real-world
+        examples. Great for anyone curious about modular Rails apps.
+      video_url: TODO
+      speakers:
+        - name: Anton Valkov
+          contact_details:
+            github_username: antulik
+            x_handle:
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle:
+            website:
+- uuid: d58e31c8-add3-4cc7-ad4c-05027a1edb52
+  date: '2023-10-26'
+  name: Bootcamp Project Showcase by Thomas Hoang & Env Var Insights by Michael S.
+  description: Dive into full stack creativity with Thomas Hoang's bootcamp project
+    and level-up your Rails security with Michael S.'s talk on environment variables.
+  slug: 2023-10-26-bootcamp-showcase-environment-variables
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+    - uuid: f9e81bae-4fb7-4029-ac76-9651fd80c6f1
+      title: Showcase of final project of my bootcamp with Academy Xi
+      description: Celebrate creativity! Join Thomas Hoang as he presents his full stack
+        web app—crafted from Rails and React—developed for his final Academy Xi bootcamp
+        project. Get inspired by a real-world journey from learning to launch!
+      video_url: TODO
+      speakers:
+        - name: Thomas Hoang
+          contact_details:
+            github_username:
+            x_handle:
+            linkedin_handle: thdev
+            bluesky_handle:
+            mastodon_handle:
+            website: https://thdev.com.au
+    - uuid: ba200eea-210a-435b-aae6-816beb9967d7
+      title: Thoughts on Environment Variables
+      description: Learn the do's and don'ts of environment variables in Rails with
+        Michael S.! Discover best practices for secrets, safe config storage, and tools
+        to keep your apps secure. See real code and real solutions in this punchy lightning
+        talk!
+      video_url: TODO
+      speakers:
+        - name: Michael S.
+          contact_details:
+            github_username: saramic
+            x_handle:
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle:
+            website:
+- uuid: 654dddc4-d390-4c72-9e9d-da42a0209a24
+  date: '2023-09-28'
+  name: Rails Forms with Anton and Power of Pair Presenting by Simran
+  description: Anton shares quick insights on Rails forms, then Simran explores how
+    pair presenting can make your talks unforgettable!
+  slug: 2023-09-28-rails-forms-and-pair-presenting
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+    - uuid: 9e4051d6-e524-45a3-9f86-3080fc56a672
+      title: Rails forms
+      description: Join Anton for a fast-paced lightning talk on Rails forms and service
+        objects! Perfect for anyone looking to streamline form handling in their Rails
+        app. Short, sharp, and super practical—don’t miss it!
+      video_url: TODO
+      speakers:
+        - name: Anton
+          contact_details:
+            github_username: antulik
+            x_handle:
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle:
+            website:
+    - uuid: f676bfb4-214e-4546-8bef-ef193a815939
+      title: 'Unleashing the Power of Pair Presenting: Elevate Your Conference Impact'
+      description: Simran reveals how pair presenting can transform your conference
+        talks! Explore the benefits, pitfalls, and exciting live demos while learning
+        to forge deeper connections and make every presentation memorable.
+      video_url: TODO
+      speakers:
+        - name: Simran Sawhney
+          contact_details:
+            github_username: simran-sawhney
+            x_handle:
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle:
+            website:
+- uuid: cf75ed65-776e-43b5-9cc7-887f87d2ad0c
+  date: '2023-08-24'
+  name: Game Dev with Map7 and Ruby Code Dive with Rian McGuire
+  description: Hear Map7 share insights from building a 2D action game in Dragonruby,
+    plus take a deep dive into Ruby code internals with Rian McGuire.
+  slug: 2023-08-24-dragonruby-and-ruby-code-dive
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+    - uuid: 253957c7-9c07-4c5d-8ca1-ea57e238405d
+      title: 'Dragonruby: Creating the game "Metal Warrior: Search for Valhalla"'
+      description: Hear Map7 share fun stories, highlights, and hurdles from building
+        their action-packed 2D game in Dragonruby. Aspiring game devs and curious coders—don’t
+        miss this energetic lightning talk!
+      video_url: TODO
+      speakers:
+        - name: Map7
+          contact_details:
+            github_username: map7
+            x_handle:
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle:
+            website:
+    - uuid: 133a4978-015c-4161-92bf-5314f3d94f05
+      title: But why does it work?
+      description: Nothing’s a black box! Rian McGuire will show you how to confidently
+        peer into unfamiliar code and languages, exploring gems and even the Ruby source.
+        Demystify how things really tick in this inspiring talk.
+      video_url: TODO
+      speakers:
+        - name: Rian McGuire
+          contact_details:
+            github_username: rianmcguire
+            x_handle:
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle:
+            website:
+- uuid: 8ad866ea-07fb-46fd-8999-7eae7ebf5a99
+  date: '2023-07-27'
+  name: Guidance for Juniors, Bug Mysteries & FHIR with Michael, radar, Matt Hood
+  description: Mentorship and TDD tips for juniors, unraveling a 27-year-old production
+    bug with radar, and Matt Hood delves into FHIR's technical power in healthcare.
+  slug: 2023-07-27-juniors-bugs-fhir
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+    - uuid: 2d63386b-6582-4c3c-b2f4-a81e0546f35c
+      title: Tips for juniors and mentors
+      description: Join Michael as he shares uplifting tips for juniors and mentors!
+        Learn about pairing up in the community, brushing up Ruby with exercism, and
+        taking your TDD and dojo skills to the next level. A quick, friendly guide for
+        all newcomers.
+      video_url: TODO
+      speakers:
+        - name: Michael
+          contact_details:
+            github_username:
+            x_handle:
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle:
+            website:
+    - uuid: f1cdbb5d-d4e0-442e-8b3d-4206b142499d
+      title: A production bug 27 years in the making
+      description: Get ready for a suspenseful bug hunt! radar unveils the story of
+        a perfectly-tested app with a bug that lay dormant for 27 years. Learn from
+        surprising production adventures. You’ll laugh, you’ll gasp, you’ll code more
+        defensively.
+      video_url: TODO
+      speakers:
+        - name: radar
+          contact_details:
+            github_username: radar
+            x_handle:
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle:
+            website:
+    - uuid: 51f10894-e251-4a37-89df-87f63327f08e
+      title: How FHIR is tackling a wicked problem with technical, social and political
+        solutions
+      description: Matt Hood explores FHIR—how it’s revolutionizing healthcare data
+        by solving technical, social, and political challenges. Ideal for Ruby devs
+        and anyone curious about interoperability and tech advocacy. Fascinating insights
+        await!
+      video_url: TODO
+      speakers:
+        - name: Matt Hood
+          contact_details:
+            github_username: MattHood
+            x_handle:
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle:
+            website:
+- uuid: cd5f7102-3430-4e44-acd4-7f0fc4da69a6
+  date: '2021-06-24'
+  name: Simple I18n with David Carlin and Exercism for Juniors with Achhetr
+  description: David Carlin shares fresh I18n simplicity tips, followed by Achhetr
+    demoing Exercism and coding approaches for junior devs.
+  slug: 2021-06-24-i18n-simplicity-exercism-juniors
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+    - uuid: 8719c47e-35c4-481f-8268-fcefbff3c129
+      title: 'Lightning talk: How to stop I18n getting complex'
+      description: Ready to stop wrestling with I18n? David Carlin reveals clever new
+        ways to keep language logic simple in your Rails apps. Clear, concise, and unlike
+        anything you've seen before—unlock a smoother multilingual workflow!
+      video_url: TODO
+      speakers:
+        - name: David Carlin
+          contact_details:
+            github_username: davich
+            x_handle:
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle:
+            website:
+    - uuid: e4edfbf7-49b7-4824-9612-b36254b2661e
+      title: Exercism for Junior Developers
+      description: Join Achhetr’s welcoming walkthrough of Exercism! See hands-on coding
+        exercises and gain TDD & pair programming confidence. Perfect for new devs looking
+        for real-world problem-solving tips and a supportive vibe.
+      video_url: TODO
+      speakers:
+        - name: Achhetr
+          contact_details:
+            github_username: achhetr
+            x_handle:
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle:
+            website:
+- uuid: d45f9d8d-270c-4942-9c8c-c9a7fab097c1
+  date: '2021-03-25'
+  name: 'The Joy of Docs: Technical Writing with Oscar Alan Pierce'
+  description: Join Oscar Alan Pierce as he shares practical tips for better technical
+    writing—make your docs fun, clear, and super useful for every developer!
+  slug: 2021-03-25-joy-of-docs-technical-writing-oscar-alan-pierce
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+    - uuid: 7d227c0b-1167-4621-9d32-d0bf6ac1c8c0
+      title: 'The Joy of Docs: Technical Writing for Developers and Engineers'
+      description: Unlock the secrets to writing documentation that actually helps!
+        Join Oscar Alan Pierce for a fun and insightful session on improving your technical
+        writing and making your docs shine. You’ll never look at commit messages the
+        same way again!
+      video_url: TODO
+      speakers:
+        - name: Oscar Alan Pierce
+          contact_details:
+            github_username: oscaralanpierce
+            x_handle:
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle:
+            website:
+- uuid: 82d763b9-afb2-4f79-b9c4-ab08c0d4e2c0
+  date: '2021-02-25'
+  name: View Components in the Wild with Vanessa Nimmo
+  description: See how Vanessa Nimmo and the team at Fresho use View Components to
+    make Rails views simpler, easier to test, and more fun to build!
+  slug: 2021-02-25-view-components-in-the-wild
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+    - uuid: 9891cde0-a3da-4baf-af84-c8a986dd34b5
+      title: View Components in the Wild
+      description: See how Fresho uses View Components to make Rails testing and frontend
+        dev wilder, more composable, and a lot more fun! Learn about decomposing UIs
+        and writing maintainable, consistent code.
+      video_url: TODO
+      speakers:
+        - name: Vanessa Nimmo
+          contact_details:
+            github_username: VanessaNimmo
+            x_handle:
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle:
+            website:

--- a/sites/melbourne/lib/melbourne.rb
+++ b/sites/melbourne/lib/melbourne.rb
@@ -1,0 +1,4 @@
+require_relative "melbourne/engine"
+
+module Melbourne
+end

--- a/sites/melbourne/lib/melbourne/data/domain_model_processor.rb
+++ b/sites/melbourne/lib/melbourne/data/domain_model_processor.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Melbourne
+  module Data
+    class DomainModelProcessor
+      def initialize(path:)
+        @json_contents = JSON.parse(File.read(path))
+      end
+
+      def process # rubocop:disable Metrics/MethodLength, Metrics/AbcSize:
+        json_contents.map do |event|
+          date = Date.parse(event["date"]).end_of_month.prev_occurring(:thursday)
+          {
+            uuid: SecureRandom.uuid,
+            date: date.to_s,
+            name: event["name"],
+            description: event["description"],
+            slug: event["slug"],
+            type: "meetup",
+            venue: {
+              name: "BOYD Community Hub",
+              google_maps_url: "https://maps.app.goo.gl/Tifehaitwnf2fJSq5",
+              address: {
+                street: "207 City Rd",
+                locality: "Southbank",
+                postal_code: "3006",
+                region: "VIC",
+                country: "AU",
+              }
+            },
+            talks: event["talks"].map do |talk|
+              {
+                id: SecureRandom.uuid,
+                title: talk["title"],
+                description: talk["description"],
+                video_url: "TODO",
+                speakers: talk["speakers"].map do |speaker|
+                  {
+                    name: speaker["name"],
+                    contact_details: {
+                      github_username: speaker.dig("contact_details", "github_username"),
+                      x_handle: speaker.dig("contact_details", "x_handle"),
+                      linkedin_handle: speaker.dig("contact_details", "linkedin_handle"),
+                      bluesky_handle: speaker.dig("contact_details", "bluesky_handle"),
+                      mastodon_handle: speaker.dig("contact_details", "mastodon_handle"),
+                      website: speaker.dig("contact_details", "website"),
+                    }
+                  }
+                end
+              }
+            end
+          }.deep_stringify_keys
+        end
+      end
+
+      private
+
+      attr_reader :json_contents
+    end
+  end
+end

--- a/sites/melbourne/lib/melbourne/data/llm_caller.rb
+++ b/sites/melbourne/lib/melbourne/data/llm_caller.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+module Melbourne
+  module Data
+    class LLMCaller # rubocop:disable Metrics/ClassLength:
+      def initialize(openai_api_key:)
+        # Define the request URL
+        uri = URI('https://api.openai.com/v1/responses')
+
+        # Create HTTP client
+        @http = Net::HTTP.new(uri.host, uri.port)
+        @http.use_ssl = true
+
+        # Create the request
+        @request = Net::HTTP::Post.new(uri)
+        @request['Content-Type'] = 'application/json'
+        @request['Authorization'] = "Bearer #{openai_api_key}"
+      end
+
+      def call(path:)
+        meetups = JSON.parse(path)
+        meetups.map do |meetup|
+          perform_request(meetup)
+        end
+      end
+
+      private
+
+      attr_reader :request, :http
+
+      def perform_request(meetup)
+        request.body = request_body(meetup).to_json
+
+        response = http.request(request)
+        parsed_response = JSON.parse(response.body)
+
+        JSON.parse(parsed_response.fetch("output").first.fetch("content").first.fetch("text"))
+      end
+
+      def request_body(event_json) # rubocop:disable Metrics/MethodLength
+        {
+          "model" => "gpt-4.1",
+          "input" => [
+            {
+              "role" => "user",
+              "content": [
+                {
+                  "type" => "input_text",
+                  "text" => "#{base_prompt} ```json #{event_json} ```"
+                }
+              ]
+            }
+          ],
+          "text" => {
+            "format" => {
+              "type" => "json_schema",
+              "name" => "event_schema",
+              "strict" => true,
+              "schema" => {
+                "type" => "object",
+                "properties" => {
+                  "date" => {
+                    "type" => "string",
+                    "description" => "The date of the event in YYYY-MM-DD format",
+                    "pattern" => "^\\d{4}-\\d{2}-\\d{2}$"
+                  },
+                  "name" => {
+                    "type" => "string",
+                    "name" => "The name of the event. 60ch max. Includes talks topics and speakers",
+                  },
+                  "description" => {
+                    "type" => "string",
+                    "description" => "A short description of the speakers and the topics.",
+                  },
+                  "slug" => {
+                    "type" => "string",
+                    "description" => "The slug of the event in YYYY-MM-DD-short-description format",
+                  },
+                  "talks" => {
+                    "type" => "array",
+                    "description" => "List of talks to be delivered at the event.",
+                    "items" => {
+                      "type" => "object",
+                      "properties" => {
+                        "title" => {
+                          "type" => "string",
+                          "description" => "Title of the talk."
+                        },
+                        "description" => {
+                          "type" => "string",
+                          "description" => "Description of the talk."
+                        },
+                        "speakers" => {
+                          "type" => "array",
+                          "description" => "List of speakers for the talk.",
+                          "items" => {
+                            "type" => "object",
+                            "properties" => {
+                              "name" => {
+                                "type" => "string",
+                                "description" => "Name of the speaker."
+                              },
+                              "contact_details" => {
+                                "type" => "object",
+                                "properties" => {
+                                  "github_username" => {
+                                    "type" => %w[string null],
+                                    "description" => "GitHub username of the speaker."
+                                  },
+                                  "x_handle" => {
+                                    "type" => %w[string null],
+                                    "description" => "X social media handle of the speaker."
+                                  },
+                                  "linkedin_handle" => {
+                                    "type" => %w[string null],
+                                    "description" => "LinkedIn handle of the speaker."
+                                  },
+                                  "bluesky_handle" => {
+                                    "type" => %w[string null],
+                                    "description" => "Bluesky handle of the speaker."
+                                  },
+                                  "mastodon_handle" => {
+                                    "type" => %w[string null],
+                                    "description" => "Mastodon handle of the speaker."
+                                  },
+                                  "website" => {
+                                    "type" => %w[string null],
+                                    "description" => "Personal website of the speaker."
+                                  }
+                                },
+                                "required" => %w[
+                                  github_username
+                                  x_handle
+                                  linkedin_handle
+                                  bluesky_handle
+                                  mastodon_handle
+                                  website
+                                ],
+                                "additionalProperties" => false
+                              }
+                            },
+                            "required" => %w[name contact_details],
+                            "additionalProperties" => false
+                          }
+                        }
+                      },
+                      "required" => %w[title description speakers],
+                      "additionalProperties" => false
+                    }
+                  }
+                },
+                "required" => %w[date talks name description slug],
+                "additionalProperties" => false
+              }
+            }
+          },
+          "reasoning" => {},
+          "tools" => [],
+          "temperature" => 1,
+          "max_output_tokens" => 2048,
+          "top_p" => 1,
+          "store" => true
+        }
+      end
+
+      def base_prompt
+        File.read(Melbourne::Engine.root.join("lib", "melbourne", "data", "prompt.md"))
+      end
+    end
+  end
+end

--- a/sites/melbourne/lib/melbourne/data/llm_preparer.rb
+++ b/sites/melbourne/lib/melbourne/data/llm_preparer.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Melbourne
+  module Data
+    class LLMPreparer
+      def initialize(path:)
+        @json_contents = JSON.parse(File.read(path))
+      end
+
+      def prepare # rubocop:disable Metrics/MethodLength
+        json_contents.map do |date, talks|
+          date = Date.parse(date).end_of_month.prev_occurring(:thursday)
+          {
+            date: date.to_s,
+            talks: talks.map do |talk|
+              {
+                id: talk["id"],
+                title: talk["title"],
+                description: talk["description"],
+                comments: talk["comments"].map do |comment|
+                  {
+                    github_username: comment["user"],
+                    body: comment["body"],
+                  }
+                end
+              }
+            end
+          }
+        end
+      end
+
+      private
+
+      attr_reader :json_contents
+    end
+  end
+end

--- a/sites/melbourne/lib/melbourne/data/llm_schema.json
+++ b/sites/melbourne/lib/melbourne/data/llm_schema.json
@@ -1,0 +1,121 @@
+{
+  "name": "event_schema",
+  "strict": true,
+  "schema": {
+    "type": "object",
+    "properties": {
+      "date": {
+        "type": "string",
+        "description": "The date of the event in YYYY-MM-DD format",
+        "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+      },
+      "summary": {
+        "type": "string",
+        "description": "A short summary of the speakers and the topics."
+      },
+      "talks": {
+        "type": "array",
+        "description": "List of talks to be delivered at the event.",
+        "items": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "Title of the talk."
+            },
+            "description": {
+              "type": "string",
+              "description": "Description of the talk."
+            },
+            "speakers": {
+              "type": "array",
+              "description": "List of speakers for the talk.",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Name of the speaker."
+                  },
+                  "contact_details": {
+                    "type": "object",
+                    "properties": {
+                      "github_username": {
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "description": "GitHub username of the speaker."
+                      },
+                      "x_handle": {
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "description": "X social media handle of the speaker."
+                      },
+                      "linkedin_handle": {
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "description": "LinkedIn handle of the speaker."
+                      },
+                      "bluesky_handle": {
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "description": "Bluesky handle of the speaker."
+                      },
+                      "mastodon_handle": {
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "description": "Mastodon handle of the speaker."
+                      },
+                      "website": {
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "description": "Personal website of the speaker."
+                      }
+                    },
+                    "required": [
+                      "github_username",
+                      "x_handle",
+                      "linkedin_handle",
+                      "bluesky_handle",
+                      "mastodon_handle",
+                      "website"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "name",
+                  "contact_details"
+                ],
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": [
+            "title",
+            "description",
+            "speakers"
+          ],
+          "additionalProperties": false
+        }
+      }
+    },
+    "required": [
+      "date",
+      "summary",
+      "talks"
+    ],
+    "additionalProperties": false
+  }
+}

--- a/sites/melbourne/lib/melbourne/data/output/events/processed/1_llm_meetups_data.json
+++ b/sites/melbourne/lib/melbourne/data/output/events/processed/1_llm_meetups_data.json
@@ -1,0 +1,808 @@
+[
+  {
+    "date": "2025-06-26",
+    "talks": [
+      {
+        "id": 3171733200,
+        "title": "Talk Proposal: The Unspoken Contract: Communicating Intent Through Code",
+        "description": "### Description(this will appear on youtube):\nCode doesn’t just tell computers what to do—it tells future developers what you meant. In this talk, we’ll explore how a simple change in a Ruby on Rails app—replacing `image_tag` with `vite_image_tag`—unintentionally broke a core abstraction, causing a baffling `JSON::NestingError`.\n\nThis bug wasn’t just about tools like Vite or Active Storage—it was a symptom of a deeper problem: intent wasn’t communicated clearly in the code.\n\nWe’ll explore the idea of unspoken contracts in software—those invisible lines where systems, assumptions, and mental models meet. Through real-world examples, you’ll learn how to:\n\n- Recognise where intent gets lost in translation\n- Communicate purpose through naming, structure, and boundaries\n- Leave better breadcrumbs for your teammates and future self\n\nWhether you're refactoring, reviewing, or just trying to be less confusing, this talk will help you write code that speaks more clearly—even when you're not there to explain it.\n\n### Estimated Talk Time:\n30 minutes\n\n### Prefered Month to Present:\nJune 2025\n\n### Preferred Social media handles:\nGitHub: HashNotAdam\nLinkedIn: HashNotAdam\n\n### Mugshot (will be use in the slides):\nSame as from our host slides",
+        "comments": []
+      }
+    ]
+  },
+  {
+    "date": "2025-04-24",
+    "talks": [
+      {
+        "id": 2990963355,
+        "title": "Talk Proposal: Make vs Justfile vs Mise",
+        "description": "Description(this will appear on youtube):\n\n## Make vs Justfile vs Mise - _choose your task runner_\n\nOverview the some task runners like **Make**, **Justfile** and **Mise** - may even take a look at [**xc**](https://xcfile.dev/) then delve into the hard questions:\n\n- why a task runner is important?\n- which ones to use and when?\n- some gotchas?\n- some common playbooks!\n- `DIAC` - Developer Infrastructure as Code - how far can we take this?\n\npresentation will be documented here: https://github.com/failure-driven/make-just-dev-runners\n\nEstimated Talk Time: `18 min`\n\nPreferred Month to Present: **April 2025**\n\nPreferred Social media handles:\n- https://github.com/saramic\n- https://x.com/saramic\n- https://www.linkedin.com/in/michael-milewski/\n- https://sessionize.com/michael-milewski/\n\nMugshot (will be use in the slides): \n\n<img src=\"https://failure-driven.com/images/michael_milewski_profile_20190421_large.jpg\" width=\"320\">\n",
+        "comments": []
+      },
+      {
+        "id": 2915946094,
+        "title": "Talk Proposal: rails 8 new",
+        "description": "Description(this will appear on youtube):\nI started a new app on January 1st using Rails 8.  It's running in production in a farily Rails 8 way with a few changes which I can explain.  Using Kamal, Action Cable, Action Text, Active Job, etc.  I'm probably doing a few things wrong too so people can correct me (Yay!  Interactive talk via Cunningham's law!)\n\nMainly I'm just really happy with Rails 8 and want to gush about it ❤ \n\nEstimated Talk Time: Can be adjusted.  Perhaps 15-30 mins.\n\nPrefered Month to Present: April\n\nPreferred Social media handles:\nhttps://www.linkedin.com/in/johnsherwooddeveloper/\nhttps://bsky.app/profile/ponny.dev\nhttps://x.com/ponny\n\nMugshot (will be use in the slides):\n![Image](https://github.com/user-attachments/assets/12913521-9b09-4f5f-82ca-b131b35a7998)",
+        "comments": [
+          {
+            "github_username": "simran-sawhney",
+            "body": "Hey @ponny I have added this as 20 minutes talk for 24th April"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2025-05-29",
+    "talks": [
+      {
+        "id": 2950841633,
+        "title": "Requested talk: How on earth do you manage forms with Turbo?",
+        "description": "Turbo is an amazing tool that usually stays out of the way. Forms, however, come with some weird and wonderful quirks that can drive you insane.\n\nI'd love to hear a talk that covers things like:\n\n- Handling errors\n  - Status codes\n  - Double rendering\n- Redirecting after a form submission (esp when used inside a Turbo Frame)\n- Disabling Turbo on a form\n- Leveraging Turbo Streams\n- Inline validations and dynamic error messaging\n- Testing Turbo interactions",
+        "comments": [
+          {
+            "github_username": "MattHood",
+            "body": "This is close to my heart, and I'm keen to do another RORO talk, so I'd love to pick this one up.\n\nIf anyone else is keen to get into this topic, feel free to get in touch - would be lovely to have a collaborator :)"
+          },
+          {
+            "github_username": "HashNotAdam",
+            "body": "This would make me very happy, @MattHood 🫶"
+          },
+          {
+            "github_username": "simran-sawhney",
+            "body": "Thanks @MattHood for the great showcase!"
+          }
+        ]
+      },
+      {
+        "id": 2937083767,
+        "title": "Talk Proposal: SQLite-ruby - a whole SQL database in a gem",
+        "description": "SQLite - the most deployed database that most people have never heard of - as a gem\n\nEstimated Talk Time: 5-20 minutes\n\nPrefered Month to Present: -\n\nPreferred Social media handles: @apocraphilia@hachyderm.io\n\n\n",
+        "comments": [
+          {
+            "github_username": "HashNotAdam",
+            "body": "Can't believe I didn't think to add this as a requested talk. SQLite is so hot right now! Brilliant topic"
+          },
+          {
+            "github_username": "simonhildebrandt",
+            "body": "When do you think we should do it?"
+          },
+          {
+            "github_username": "simran-sawhney",
+            "body": "Hey @simonhildebrandt we can do this May if you like ? "
+          },
+          {
+            "github_username": "simonhildebrandt",
+            "body": "Sure - I'm in no rush if we wanna give other people a go, though. 😁 "
+          },
+          {
+            "github_username": "dkam",
+            "body": "I’m happy to do this for May, if Simon’s ok with that? I’d be aiming for a regular length talk rather than a lightning talk though. "
+          },
+          {
+            "github_username": "simonhildebrandt",
+            "body": "That'd be awesome, @dkam !\n"
+          },
+          {
+            "github_username": "simran-sawhney",
+            "body": "Hey @dkam, are you planning to go for this one this month? \nSince we don’t have much lined up, I guess we could go for a proper talk instead lightning talk!\n\n"
+          },
+          {
+            "github_username": "simran-sawhney",
+            "body": "Thanks @dkam for the amazing talk :) "
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2025-03-27",
+    "talks": [
+      {
+        "id": 2944675321,
+        "title": "Talk Proposal: Panel/Discussion/Riffing Session on Objects to encapsulate business logic",
+        "description": "Description(this will appear on youtube):\nA discussion about where to put business logic that may not belong in a traditional Rails Model. \n\nEstimated Talk Time:\n50 min\n\nPrefered Month to Present:\nMarch 2025\n\nPreferred Social media handles:\n@pinzonjulian @HashNotAdam \n",
+        "comments": [
+          {
+            "github_username": "simran-sawhney",
+            "body": "Thanks @pinzonjulian and @HashNotAdam - it was so cool and great idea to engage the audience :) "
+          }
+        ]
+      },
+      {
+        "id": 2941730105,
+        "title": "Talk Proposal: Rack Fundamentals revisited",
+        "description": "Description(this will appear on youtube): Learn the machinery that underpins our favourite frameworks, and why you might not need a whole Rails stack for an API that's basically a single method.\n\nEstimated Talk Time: 20 minutes\n\nPreferred Month to Present: March 2025\n\nPreferred Social media handles: @apocraphilia@hachyderm.io\n\nMugshot (will be use in the slides):\n\n![Image](https://github.com/user-attachments/assets/cc2b687a-6983-4093-8090-50112f772c87)\n",
+        "comments": [
+          {
+            "github_username": "simran-sawhney",
+            "body": "Thanks @simonhildebrandt - it was really insightful"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2025-02-27",
+    "talks": [
+      {
+        "id": 2855880198,
+        "title": "Talk Proposal: Semantic Search and RAG with Ruby",
+        "description": "Description: From Embeddings to RAG: Building a Smart Search System in Ruby\n\nEstimated Talk Time: 20 minutes\n\nPrefered Month to Present: Feb\n\nPreferred Social media handles: @dkam on [GitHub](https://github.com/dkam/) and [Ruby Social](https://ruby.social/@dkam)\n\nMugshot (will be use in the slides):\n\n![Image](https://github.com/user-attachments/assets/6efe8b1d-3019-4c0d-b473-38aab5f50165)\n\n\n",
+        "comments": [
+          {
+            "github_username": "HashNotAdam",
+            "body": "Thanks, @dkam, I'm looking forward to it"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2025-01-30",
+    "talks": [
+      {
+        "id": 2808179722,
+        "title": "Talk Proposal: The Inner Workings of Puma",
+        "description": "Description(this will appear on youtube): Most Rubyists use the Puma web server to handle requests, especially in their Rails applications. But how many of us truly understand its design, inner workings, and the powerful features it offers? In this session, we’ll dive into Puma’s internals, exploring its architecture and configuration options.\n\nEstimated Talk Time: 30-40 minutes\n\nPrefered Month to Present: January\n\nPreferred Social media handles:\n- https://bsky.app/profile/joshuay03.bsky.social\n- https://ruby.social/@joshuay03\n\nMugshot (will be use in the slides):\n![Image](https://github.com/user-attachments/assets/cad2ea3c-23f1-4c93-9222-b3e42a952b32)",
+        "comments": []
+      },
+      {
+        "id": 2808082071,
+        "title": "Talk Proposal: Ruby salad. What's fresh on the market?",
+        "description": "Description(this will appear on youtube): A review of some of new features in ruby 3.4 and rails 8. Including rails authentication generators and rodauth comparison.\n\nEstimated Talk Time: 40min\n\nPrefered Month to Present: January\n\nPreferred Social media handles: antulik on ruby slack\n\nMugshot (will be use in the slides): \n\n![Image](https://github.com/user-attachments/assets/ed08caaa-b142-4687-a3f5-43c1ca040bf6)\n",
+        "comments": []
+      }
+    ]
+  },
+  {
+    "date": "2024-10-24",
+    "talks": [
+      {
+        "id": 2550597828,
+        "title": "Talk Proposal:  'Cursor v Github Copilot: building a better data schema tool?'",
+        "description": "Description:\r\nAn evaluation of [Cursor](https://www.cursor.com/), how to configure it, which AI model to use, and a look at the pros and cons of [Cursor](https://www.cursor.com/) compared to GitHub Copilot.\r\n\r\nEstimated Talk Time:\r\n10–15 minutes\r\n\r\nPrefered Month to Present: October\r\n\r\nPreferred Social media handles: @ceels\r\n\r\nMugshot (will be use in the slides): lemme find one real quick\r\n![image](https://github.com/user-attachments/assets/e44e1475-2a29-48a3-ab50-636d63f06f63)\r\n\r\n",
+        "comments": [
+          {
+            "github_username": "HashNotAdam",
+            "body": "Thanks, @ceels, I can't wait to watch"
+          },
+          {
+            "github_username": "simran-sawhney",
+            "body": "Locking this for October @ceels - see you on 24th :) "
+          }
+        ]
+      },
+      {
+        "id": 2455100965,
+        "title": "Talk Proposal: Happy Ruby SAML Development",
+        "description": "**Description (this will appear on YouTube):**\r\n\r\nThis talk is an introduction to how SAML requests and responses can be handled with Ruby, as well as a discussion around how we at [Covidence](https://www.covidence.org) have solved such challenges as:\r\n\r\n* Building SAML support ourselves rather than using third-party services.\r\n* Writing full feature tests to sign in via SSO (no mocking of SAML objects/responses).\r\n* Bridging SAML requests across many domains for staging/PR apps, to ensure a consistent approach across environments.\r\n* Parsing SAML metadata files using Nokogiri for better performance.\r\n\r\n**Estimated Talk Time:**\r\n\r\n20-30 minutes\r\n\r\n**Preferred Month to Present:**\r\n\r\nOctober or November 2024 (I'm away prior to that, sorry!)\r\n\r\n**Preferred Social media handles:**\r\n\r\nhttps://hachyderm.io/@pat\r\n\r\n**Mugshot (will be use in the slides):**\r\n\r\n![](https://media.hachyderm.io/accounts/avatars/109/308/312/683/593/994/original/49c39d379fbc3d37.jpg)\r\n[https://media.hachyderm.io/accounts/avatars/109/308/312/683/593/994/original/49c39d379fbc3d37.jpg](https://media.hachyderm.io/accounts/avatars/109/308/312/683/593/994/original/49c39d379fbc3d37.jpg)",
+        "comments": [
+          {
+            "github_username": "simran-sawhney",
+            "body": "Hey @pat do you wanna go for it this month on 24th Oct ?"
+          },
+          {
+            "github_username": "pat",
+            "body": "@simran-sawhney yup, let's lock it in 😁"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2024-11-28",
+    "talks": [
+      {
+        "id": 2549232104,
+        "title": "Talk Proposal: Turbo (Hotwire), Stimulusjs and being happy with front end development again",
+        "description": "Description(this will appear on youtube):\r\n\r\nI've done a lot of front end development work in my career. Think React, AngularJS, Rails UJS and JQuery enhanced pages. At no point can I say that I've enjoyed any of them, I was giving serious consideration to re-branding away from a full stack dev.\r\n\r\nEnter Hotwire and I'm actually enjoying it.\r\n\r\nThis is a peak into what life is like building and maintaining a modern Rails webapp.\r\n\r\nEstimated Talk Time:  15 - 20 mins?  I'll try and keep it short\r\n\r\nPreferred Month to Present: November 2024. I may have something for the October 24th meetup but I'll also only just be back from holidays...\r\n\r\nPreferred Social media handles: Twitter @gardengnome_au (in case anyone is still there...)\r\n\r\nMugshot (will be use in the slides):\r\n![image](https://github.com/user-attachments/assets/0d2f7fe2-829f-4781-93b6-2cf0ac9017e4)\r\n\r\n",
+        "comments": [
+          {
+            "github_username": "simran-sawhney",
+            "body": "Hey @jeropaul - do you wanna do this on 28th November? "
+          },
+          {
+            "github_username": "friendlyantz",
+            "body": "keen! also interested in your take on HTMX"
+          },
+          {
+            "github_username": "jeropaul",
+            "body": "@simran-sawhney yes I'll do this on the 28th of November"
+          },
+          {
+            "github_username": "simran-sawhney",
+            "body": "hey @jeropaul - I was trying to find you over ruby Slack, couldnt come across your profile.\r\nSee you on 28th at BOYD library."
+          },
+          {
+            "github_username": "jeropaul",
+            "body": "Absolutely talk is ready! See you then.  (I'll also join slack)\r\n\r\nOn Fri, Nov 22, 2024, 10:07 Simran Sawhney ***@***.***> wrote:\r\n\r\n> hey @jeropaul <https://github.com/jeropaul> - I was trying to find you\r\n> over ruby Slack, couldnt come across your profile.\r\n> See you on 28th at BOYD library.\r\n>\r\n> —\r\n> Reply to this email directly, view it on GitHub\r\n> <https://github.com/rubyaustralia/melbourne-ruby/issues/244#issuecomment-2492535482>,\r\n> or unsubscribe\r\n> <https://github.com/notifications/unsubscribe-auth/AAD7GGPCO5JAW7AXQYHFPVL2BZRRLAVCNFSM6AAAAABO3YX2QWVHI2DSMVQWIX3LMV43OSLTON2WKQ3PNVWWK3TUHMZDIOJSGUZTKNBYGI>\r\n> .\r\n> You are receiving this because you were mentioned.Message ID:\r\n> ***@***.***>\r\n>\r\n"
+          }
+        ]
+      },
+      {
+        "id": 2537782432,
+        "title": "Requested Talk: How do `CurrentAttributes` work?",
+        "description": "**Description:**\r\nRails includes a class called `ActiveSupport::CurrentAttributes` that can be used to store values that relate only to the current request or job.\r\n\r\nFor example:\r\n```ruby\r\nclass Current < ActiveSupport::CurrentAttributes\r\n  attribute :user\r\nend\r\n\r\nCurrent.user = User.first\r\n```\r\n\r\nHow does Rails store these values?\r\nHow can it ensure these values can only be read in the current request?\r\nWhat happens when you change the isolation level?\r\nFrom a practical standpoint, what does the isolation level mean?\r\n\r\n**Estimated Talk Time:**\r\n10–15 minutes",
+        "comments": [
+          {
+            "github_username": "darkfishy",
+            "body": "@HashNotAdam and @simran-sawhney\nI could talk about this in November, with proper presentation slides then 😅"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2024-09-26",
+    "talks": [
+      {
+        "id": 2537778854,
+        "title": "Requested Talk: How does `reload!` work?",
+        "description": "**Description:**\r\nWhen using the Rails console, you can call `reload!` to reset the environment.\r\nHow does this work?\r\nHow does it know which classes to reload?\r\nHow does a class get reloaded?\r\nWhat are the implications for intializers?\r\n\r\n**Estimated Talk Time:**\r\n10–15 minutes",
+        "comments": [
+          {
+            "github_username": "darkfishy",
+            "body": "@HashNotAdam and @simran-sawhney I can present on this topic at the next meeting."
+          },
+          {
+            "github_username": "HashNotAdam",
+            "body": "Thanks so much, @darkfishy, that's a big help. Would you might filling out the following?\r\n\r\nDescription(this will appear on youtube):\r\n\r\nPreferred Social media handles:\r\n\r\nMugshot (will be use in the slides):\r\n"
+          },
+          {
+            "github_username": "darkfishy",
+            "body": "Hey @HashNotAdam \r\n\r\n> Description(this will appear on youtube):\r\n\r\nSame as above in https://github.com/rubyaustralia/melbourne-ruby/issues/241#issue-2537778854\r\n\r\n> Preferred Social media handles:\r\n\r\nhttps://x.com/fusionfish\r\n\r\n> Mugshot (will be use in the slides):\r\n\r\nSupplied to @simran-sawhney \r\n"
+          },
+          {
+            "github_username": "simran-sawhney",
+            "body": "Thanks @darkfishy for putting it all together :) "
+          }
+        ]
+      },
+      {
+        "id": 2520782749,
+        "title": "Talk Proposal: Oaken - A fresh take on seeds and fixtures",
+        "description": "Description(this will appear on youtube): Exploring Oaken - A fresh take on seeds and fixtures\n\nEstimated Talk Time: 30min\n\nPrefered Month to Present: September \n\nPreferred Social media handles: pinzonjulian everywhere\n\nMugshot (will be use in the slides): TBD",
+        "comments": [
+          {
+            "github_username": "pinzonjulian",
+            "body": "This addresses two past issues I posed a while ago for talks I wanted to see!\n#159\n#168"
+          },
+          {
+            "github_username": "HashNotAdam",
+            "body": "You have my attention with that title 😃 "
+          },
+          {
+            "github_username": "HashNotAdam",
+            "body": "@pinzonjulian I've used the photo from GitHub, but you're welcome to supply another"
+          },
+          {
+            "github_username": "simran-sawhney",
+            "body": "Thanks @pinzonjulian, it was a great talk!"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2024-08-29",
+    "talks": [
+      {
+        "id": 2446778748,
+        "title": "Talk Proposal: My Career Change - Nothing is what it seems",
+        "description": "Description(this will appear on youtube):\r\nMy career change story: why am I here? How did I get here? This is the talk I gave at the Rails Girls Workshop to hopefully inspire others to make the change, or at the very least provide some entertaining and relatable anecdotes.\r\n\r\nEstimated Talk Time: 10 mins\r\n\r\nPreferred Month to Present: August 2024\r\n\r\nPreferred Social media handles: Twitter @cinnamonbabies, https://www.linkedin.com/in/helen-stonehouse/\r\n\r\nMugshot (will be use in the slides): \r\n![bratbg](https://github.com/user-attachments/assets/5edba73e-f5cc-463d-992c-144359eaddbb)\r\n\r\n",
+        "comments": []
+      },
+      {
+        "id": 2437892166,
+        "title": "Talk Proposal: Rails Engines in 20 minutes",
+        "description": "Description(this will appear on youtube):\r\nIn this talk, we'll walk through building a basic Rails plugin and talk about the different ways of extending Rails through Engines.\r\n\r\nEstimated Talk Time: \r\n20mins\r\n\r\nPrefered Month to Present: \r\nAugust\r\n\r\nPreferred Social media handles: \r\n@excid3\r\n\r\nMugshot (will be use in the slides):\r\nhttps://rubyonrails.org/assets/world/2023/images/speakers/c-oliver.jpg",
+        "comments": [
+          {
+            "github_username": "simran-sawhney",
+            "body": "Thanks @excid3 - community would be so proud and excited to hear it from you !!!🔥"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2024-07-25",
+    "talks": [
+      {
+        "id": 2363828597,
+        "title": "Talk Proposal: Pinkest Pink",
+        "description": "Description:\r\nDid you know the web got new colors? The pink is pinker than it used to be. The colors are so bright and we can use them on web pages. I'm not an expert in this space but I am excited to share what I've learned about the topic, like how our eyes work and how we try to recreate reality on a screen.\r\n\r\nEstimated Talk Time: 10 or 20min, can probably scope it to a lightning talk if it's better for timing\r\n\r\nPrefered Month to Present: No preference, can do with short notice if needed\r\n\r\nPreferred Social media handles: `@danlaush`, https://danlaush.biz/\r\n\r\nMugshot (will be use in the slides):\r\nhttps://github.com/rubyaustralia/melbourne-ruby/assets/1204500/da13da31-84bb-4e52-baa5-372a7f304195\r\n\r\n",
+        "comments": [
+          {
+            "github_username": "simran-sawhney",
+            "body": "hey @danlaush - do you wanna do this for this month at 25th July?"
+          },
+          {
+            "github_username": "danlaush",
+            "body": "Hey Simran, sure I'd be happy to. It's pretty solid with a 15min run time, does that work?"
+          },
+          {
+            "github_username": "simran-sawhney",
+            "body": "Hey @danlaush yep that will work fine. Let's do it mate on 25th July (Thursday)\r\nHere is the event details. https://www.meetup.com/ruby-on-rails-oceania-melbourne/events/297781282/"
+          },
+          {
+            "github_username": "simran-sawhney",
+            "body": "Hey @danlaush - could you please confirm it so I can lock it in for the event?\r\nThanks mate,"
+          },
+          {
+            "github_username": "danlaush",
+            "body": "Oh whoops I didn't submit what I wrote earlier! Yes I'm in, thanks for accepting and looking forward to it."
+          },
+          {
+            "github_username": "danlaush",
+            "body": "@simran-sawhney do you need a PDF/document for the talk or will I be able to plug my laptop in?"
+          },
+          {
+            "github_username": "simran-sawhney",
+            "body": "Sorry I just saw your comment now, thanks for the amazing talk last night!"
+          }
+        ]
+      },
+      {
+        "id": 2301498429,
+        "title": "Talk Proposal: Being a Good Male Ally",
+        "description": "Description(this will appear on youtube):\r\nBeing a Good Male Ally\r\n\r\nEstimated Talk Time:\r\n15-20 minutes. \r\nPrefered Month to Present:\r\nMay\r\nPreferred Social media handles:\r\nhttps://nickwolf.com.au",
+        "comments": [
+          {
+            "github_username": "simran-sawhney",
+            "body": "hey @quintrino - do you wanna do this on 25th July - Thursday?"
+          },
+          {
+            "github_username": "quintrino",
+            "body": "Sounds good to me. "
+          },
+          {
+            "github_username": "simran-sawhney",
+            "body": "Thanks for the amazing talk!"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2024-06-27",
+    "talks": [
+      {
+        "id": 2271079974,
+        "title": "Talk Proposal: One does not simply... rebuild a product",
+        "description": "Description(this will appear on youtube): \r\n\r\n\"A rebuild is never finished, only started\"\r\n\r\nWe're rebuilding Culture Amp's second largest product - Performance. It's 9 years old, came in as a Series A acquisition 5 years ago, has over 2700 customers with the largest one at 77k users. Against conventional wisdom, we're rebuilding it from the ground up with an aggressive timeline. The underlying model is outdated, slow to iterate on, and not extensible. The monoliths are riddled with tech debt, tightly coupled, patched and band-aided over many times, and won't scale to the $3b global Performance market we're targeting.\r\n\r\nThat wasn't challenging enough already so I'm also using this opportunity to rebuild our engineering culture. Setting a high bar for engineering standards, ways of working, and hoping to improve engagement as we go.\r\n\r\nIn this talk, I'll share:\r\n\r\n- How I came to this decision\r\n- How we got buy in from Exec and the Board for a purely technical rebuild\r\n- How we tried to set up for success, our principles and standards\r\n- Where we failed\r\n- Where we succeeded\r\n- Lessons that could be useful for anyone thinking about rebuilding a product that's hampering speed and hindering your ability to innovate or deliver value to your customers.\r\n\r\nThe rebuild is still in progress. I don't have all the answers (or any!). But we've already learned much - what to do, what not to do, and where the spiders are hiding.\r\n\r\nEstimated Talk Time: 35 - 40 minutes\r\n\r\nPreferred Month to Present: June\r\n\r\nPreferred Social media handles: https://www.linkedin.com/in/prakritimateti/\r\n\r\nMugshot (will be use in the slides): [link to photo](https://github.com/rubyaustralia/melbourne-ruby/assets/502956/6fd7dfe4-5f49-4c48-bccd-8784e41e48b7)\r\n\r\n\r\n",
+        "comments": [
+          {
+            "github_username": "simran-sawhney",
+            "body": "Thanks @itirkarp - let's do it this month on 27th June "
+          }
+        ]
+      },
+      {
+        "id": 2254940264,
+        "title": "Laravel, meet my friend Turbo",
+        "description": "I've been playing around with the PHP framework, Laravel, and looking at how to use it with Turbo, Turbo Native, and Strada.\r\n\r\nI will be giving a full talk for the PHP community that includes explanations of Turbo, Turbo Native, and Strada, as well as a comparison between Turbo and Livewire.\r\n\r\nIt would be simple enough for me to modify the talk to fit a Ruby audience, and I could set the length based on the other talks that will be given on that day. For example, if this were a full talk, I could discuss what Laravel is, the similarities to Rails, and dig a bit into the line between Turbo Native and Strada. If it were to be a lightning talk, we could skip most of the background and just do a walkthrough.",
+        "comments": []
+      }
+    ]
+  },
+  {
+    "date": "2024-05-30",
+    "talks": [
+      {
+        "id": 2251647844,
+        "title": "Cursors: Why Pagination is Bad-gination!",
+        "description": "Using Ruby to explain a popular new approach to accessing and displaying data, without the staleness issues of traditional pagination - cursors! Learn the basic concepts, and find out why this approach is popular in modern toolkits like GraphQL.\r\n\r\nProbably 20 to 30 minutes.",
+        "comments": []
+      }
+    ]
+  },
+  {
+    "date": "2024-04-25",
+    "talks": [
+      {
+        "id": 2245115139,
+        "title": "Dissecting Rails",
+        "description": "Lightning talk for RORO Melbourne\r\n\r\n__Title:__ Dissecting Rails \r\n__About:__ How I learn Rails. My takeaways from dissecting Rails: Active Support, Active Model, etc\r\n\r\n__Timing:__ APR-2024\r\n\r\n>    Are you happy to have your talk published on the RubyAU YouTube channel? -> yes\r\n    Your Twitter username (if you have one) -> [@friendlyantz](https://twitter.com/friendlyantz)\r\n    Link to, or upload of, a photo of yourself that will appear in the meetup slide deck: refer https://github.com/rubyaustralia/melbourne-ruby/issues/192\r\n\r\nLength: 10-15min",
+        "comments": [
+          {
+            "github_username": "simran-sawhney",
+            "body": "Thanks @friendlyantz for your insightful talk :) "
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2024-03-28",
+    "talks": [
+      {
+        "id": 2166041203,
+        "title": "One Billion Rows in Ruby",
+        "description": "Description(this will appear on youtube):\r\nIs Ruby a good language for CPU-intensive data crunching? Can it beat Java? This talk is about my adventures taking on the One Billion Row Challenge (https://github.com/gunnarmorling/1brc) in Ruby. I'll cover some of the tools, techniques and pitfalls around optimising Ruby programs.\r\n\r\nEstimated Talk Time: maybe 30 minutes? (haven't timed it yet)\r\n\r\nPreferred Month to Present: March 2024\r\n\r\nPreferred Social media handles: None\r\n\r\nMugshot (will be use in the slides): https://avatars.githubusercontent.com/u/1201065",
+        "comments": [
+          {
+            "github_username": "simran-sawhney",
+            "body": "Thanks @rianmcguire - let's do it on 28th March!"
+          },
+          {
+            "github_username": "simran-sawhney",
+            "body": "Thanks @rianmcguire for your amazing talk!"
+          }
+        ]
+      },
+      {
+        "id": 2165644521,
+        "title": "The Economics of Ruby",
+        "description": "Description(this will appear on youtube):\r\nJohn is a developer that likes both Ruby and Economics.  \r\n\r\nThis is a lightning talk about the flow of resources and incentives in the Ruby ecosystem.  It will discuss the costs of maintaining Ruby, the support from various benefactors/companies, and the contributors that make it all happen.\r\n\r\nEstimated Talk Time: 10 minutes\r\n\r\nPrefered Month to Present: March 2024\r\n\r\nPreferred Social media handles: \r\nhttps://twitter.com/ponny\r\n\r\nMugshot (will be use in the slides): just use my github avatar\r\n",
+        "comments": [
+          {
+            "github_username": "simran-sawhney",
+            "body": "Thanks @ponny - let's do this on 28th March! "
+          },
+          {
+            "github_username": "simran-sawhney",
+            "body": "Thanks @ponny for your amazing talk!"
+          },
+          {
+            "github_username": "ponny",
+            "body": "@simran-sawhney No worries.  A couple of people asked for the vid so could you please post it here when it's up?"
+          },
+          {
+            "github_username": "simran-sawhney",
+            "body": "@ponny here is the posted video link!\r\nhttps://www.youtube.com/watch?v=ydU3WvLoXpY\r\n"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2024-02-22",
+    "talks": [
+      {
+        "id": 2126276849,
+        "title": "Can I host a rails app from a home server?",
+        "description": "With the advent of cloud and the availability of PaaS (Platform as a Service) providers like Heroku, Fly.io, Render, and Hatchbox, why would even consider running a **rails app** on **bare metal** from home?\r\n- because you can?\r\n- because it's cheaper?\r\n- because you want to be your own sysadmin/devops?\r\n- because you want the internet to be back like it was in **1999 🎉 !!!**\r\n- because there has been some recent noise on this in the Rails community\r\n    **[RECLAIM THE STACK!](https://reclaim-the-stack.com/)**\r\n    > We spent 7 months building a Kubernetes based platform to replace Heroku. The results were a 90% reduction in costs and a 30% improvement in performance.\r\n    \r\n    **[KAMAL](https://kamal-deploy.org/)** _formerly MRSK_\r\n    > Leaving the cloud will save us $7 million over five years.\r\n    https://basecamp.com/cloud-exit\r\n- because @friendlyantz - wants to know\r\n    [Ruby Australia Slack #melb-meets 3:27pm Oct 5 2023](https://rubyau.slack.com/archives/C010RUGPRHU/p1696480053027199?thread_ts=1696479747.231869&cid=C010RUGPRHU)\r\n  > Keen to hear about these topics(hope it inspires someone):\r\n  >  * Self hosting ruby app\r\n\r\nSo **\"can I host a rails app from a home server?\"** whats involved? how hard can it be? is it just `RAILS_ENV=production bin/rails server`?\r\n\r\nlet's see how far I can get - maybe a **5 minute talk** or maybe **30 minutes** depending how far I get\r\n\r\nNOTE: _this is part of a larger talk idea for running a rails app locally on **bare metal** using a laptop, moving it into the **cloud☁️** and back again on-premise on **bare metal** home cluster_\r\n\r\n",
+        "comments": [
+          {
+            "github_username": "simran-sawhney",
+            "body": "Thanks for the great talk @saramic ! "
+          }
+        ]
+      },
+      {
+        "id": 2112381409,
+        "title": "Talk Proposal : System Design & Distributed System Lightweight Concept",
+        "description": "- What to do when our app gains popularity (Vertical & Horizontal Scaling)\r\n- Horizontal scaling best practices (instance stickiness, louse coupling ) \r\n-  Distributed Systems ( stuff like chaos monkeys, retry mechanism should be somewhat fun )\r\n- Could also talk abt some tools like kubernetes ( just the lightweight stuff like k8 backgrounds, pods, deleting pods , scalling , and a bit abt writing .yaml file not the advanced or super detailed ) . ",
+        "comments": [
+          {
+            "github_username": "simran-sawhney",
+            "body": "hey @Stefanuswilfrid - . It's a great topic but for it to be qualified for lightning talk, this seems bit too heavy. Is there any chance if you could decrease the presentation and talk time to 10 minutes maximum and realign the details in your slides accordingly ?"
+          },
+          {
+            "github_username": "ZimbiX",
+            "body": "Or have it be a full talk?"
+          },
+          {
+            "github_username": "Stefanuswilfrid",
+            "body": "hey , ur right i think for the lightning talk i'l just talk abt 'scaling you app 101' . in the bginning i thought i was supposed to propose about topics for multiple weeks lol. "
+          },
+          {
+            "github_username": "simran-sawhney",
+            "body": "Thanks for the talk @Stefanuswilfrid ! "
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2024-01-25",
+    "talks": [
+      {
+        "id": 2080633355,
+        "title": "Processing DMARC reports via Action Mailbox",
+        "description": "Domain-based Message Authentication, Reporting, and Conformance (or DMARC) is an email validation system that builds upon Sender Policy Framework (SPF) and DomainKeys Identified Mail (DKIM) to protect email domains from being used in email spoofing, phishing scams, and other cybercrime.\r\n\r\nWhen creating a DMARC DNS record, you can include a `rua` attribute, the value of which is an email address that servers can send a daily report of the deliverability of emails from your domain. This provides valuable data that can help you check that you've approved every server that you expect to be able to send on your behalf and reduce the number of legitimate emails that are sent to spam. Unfortunately, these reports come as XML files which are usually GZipped which makes them poorly suited to human reading. Also, since they are sent by the receiving servers, you can expect to be sent many reports per day.\r\n\r\nThis talk is the story of how I leveraged Action Mailbox in Ruby on Rails to automatically parse incoming DMARC reports and alert me to issues in a human-readable format.",
+        "comments": [
+          {
+            "github_username": "simran-sawhney",
+            "body": "Thanks for the great talk @HashNotAdam "
+          }
+        ]
+      },
+      {
+        "id": 2075457487,
+        "title": "Something Something Fibers Something",
+        "description": "Yes, the title of the talk is \"Something Something Fibers Something\" - I'll try and nail down more specifically what I want to talk about this weekend :)\r\n\r\nI'd like to do a talk that really gets into the low-level guts of how fibers work in Ruby. The rough kind of thing I'm thinking of covering is...\r\n\r\n* What a Fiber is, and how fibers relate to threads\r\n* How Fiber.yield/Fiber.resume work in Ruby\r\n* What you can build with them (e.g. implementing enumerators with them, \"saving\" the context of being inside a block)\r\n* How the Ruby and C call stacks relate to each other (this is important prerequisite info which is kind of genuinely interesting on its own)\r\n* How Fiber.yield and Fiber.resume are implemented in terms of the C call stack\r\n\r\nI would also like to talk about Fiber.transfer & the new Ruby fiber scheduler interface & the async gem, but let's see how much content ☝️  turns out to be. Maybe it's a different talk for another time.\r\n\r\nI'll be able to present this on Jan 25.",
+        "comments": [
+          {
+            "github_username": "ZimbiX",
+            "body": "Very cool. I've been keen for a talk like this since Ruby 3 came out :grin:"
+          },
+          {
+            "github_username": "simran-sawhney",
+            "body": "Thanks for the great talk @KJTsanaktsidis "
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2023-11-23",
+    "talks": [
+      {
+        "id": 2010461264,
+        "title": "Proposal: precious gems I've learned during my first dev year (10-15min lightning talk)",
+        "description": "Title: Precious gems I've learned in my first dev year\r\nAbout: Not the ruby gems but more like gems of wisdom that I've experienced during my first developer year. Lots of self reflection to be done and just want to share some of them\r\n\r\nTiming: 29th Nov 2023\r\nLength: 10 - 15min Lightning talk",
+        "comments": [
+          {
+            "github_username": "optimistic-updt",
+            "body": "hey Justin, \r\nAre you keen to do this in November?\r\n"
+          },
+          {
+            "github_username": "j-tws",
+            "body": "Yeah can do! That will be this coming Wed right?"
+          },
+          {
+            "github_username": "optimistic-updt",
+            "body": "yep"
+          }
+        ]
+      },
+      {
+        "id": 1929166227,
+        "title": "[discussion]: Rails architecture with engines work group",
+        "description": "I'll demo an app and talk about my experience for a little bit. The goal is to have an audience discussion and share experiences about using rails engines. Other people are welcome to demo their examples as well.\r\n\r\nLength: 1-1.5 hour discussion",
+        "comments": [
+          {
+            "github_username": "optimistic-updt",
+            "body": "that sounds awesome,\r\nLet's maybe have it in november ❤️ \r\n"
+          },
+          {
+            "github_username": "optimistic-updt",
+            "body": "are you stil happy to this next week?"
+          },
+          {
+            "github_username": "antulik",
+            "body": "yes"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2023-10-26",
+    "talks": [
+      {
+        "id": 1956158778,
+        "title": "Proposal: Showcase of final project of my bootcamp with Academy Xi",
+        "description": "Description: A showcase of my full stack web app built for the final project of the bootcamp I have completed with Academy Xi. Made with Rails and React\r\n\r\nTalk time: 20mins \r\n\r\nMonth: October\r\n\r\nSocial Media: \r\nhttp://linkedin.com/in/thdev\r\n\r\nPortfolio \r\nThdev.com.au\r\n\r\n![IMG_1742](https://github.com/rubyaustralia/melbourne-ruby/assets/59306359/5ae6893b-4249-480a-942e-33bd88cba93b)\r\n",
+        "comments": []
+      },
+      {
+        "id": 1956091676,
+        "title": "Thoughts on Environment Variables",
+        "description": "A lightning talk 5 - 10 minutes on managing environment variables in rails.\r\n\r\n> You're app is coming along and all of a sudden you need to configure the number of workers, or an endpoint to access an API. You reach for `CONSTANTS` but very quickly you find out that these will vary between **development**, **test** and **production** apps. Not only that but you have a number of **\"production\"** apps like _staging_, _sandbox_, _UAT_ and the like. You also read up about [The Twelve-Factor App](https://12factor.net/) and you go for **Environment Variables** (`ENV_VARS`) to configure everything. But development becomes a night mare so you use `.env` files to store all these configurations. And then you get an API **Key 🔑** or **Secret 🔐** and you also through it into the `.env` file and even commit it to Git!!! 🚨 - at night you here yourself counselling yourself\r\n>    \"it's OK, it's a private repo\"\r\n>    \"it's OK, it's only a developer secret\"\r\n\r\nIt's **NOT OK** this is the kind of behaviour that leads to security breaches and people being fired! - let's not blame the individuals but the process. The process of not having an easy way to store and share secrets is the root of the problem, and not developers accidentally sharing secrets they haphazardly saved to their publicly visible `.Dotfiles` git hub repo\r\n\r\nLearn:\r\n1. why to use Env Vars\r\n2. how to use `.env` https://github.com/bkeepers/dotenv and why it's a bad idea\r\n3. how to use **rails credentials** as well as Shopify's EJson, or Mozillas SOPS or Ansible's Vault\r\n4. how to easily manage and override credentials using Evil Martians AnywayConfg\r\n5. and why you should never be complacent with the way things are - learn how to break your system to make a better system\r\n\r\nwith code examples - https://github.com/failure-driven/env-var-demo",
+        "comments": [
+          {
+            "github_username": "ponny",
+            "body": "Keen for this."
+          },
+          {
+            "github_username": "saramic",
+            "body": "@ponny - not sure I did the topic justice but in case you were interested -> https://www.youtube.com/watch?v=Pf-IrWRm-UE"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2023-09-28",
+    "talks": [
+      {
+        "id": 1870695080,
+        "title": "Talk proposal: Rails forms",
+        "description": "I can do a lighting talk about rails forms and service objects",
+        "comments": [
+          {
+            "github_username": "friendlyantz",
+            "body": "yes please!"
+          },
+          {
+            "github_username": "simran-sawhney",
+            "body": "Alright let's do mate this month @antulik"
+          },
+          {
+            "github_username": "antulik",
+            "body": "it's a lightning talk, so 5min, but will probably stretch to 10min."
+          }
+        ]
+      },
+      {
+        "id": 1784427256,
+        "title": "Unleashing the Power of Pair Presenting: Elevate Your Conference Impact",
+        "description": "I was commissioned to write this talk for an international group, put in a lot of effort, heard the content was great, and would like to share it with all of you!\r\n\r\n\r\nDescription:\r\nDiscover the transformative potential of pair presenting at conferences in this captivating presentation. Explore the principles behind successful collaborations, understanding the advantages and disadvantages of this dynamic approach and how it can elevate your impact.\r\nGain insights into leveraging unique personalities and strengths, assessing the need for two speakers, and understanding the perception created, while incorporating engaging live code demonstrations and interactive elements.\r\nRecognize the importance of strong male allies in fostering inclusivity and integration. Harness the power of pair presenting to maximize your conference impact, forge meaningful connections, and empower you to make a lasting impression on your audience.",
+        "comments": []
+      }
+    ]
+  },
+  {
+    "date": "2023-08-24",
+    "talks": [
+      {
+        "id": 1823402011,
+        "title": "Dragonruby: Creating the game \"Metal Warrior: Search for Valhalla\"",
+        "description": "A lightening talk proposal (5mins) just going over some of the highlights and issues we had whilst creating a 2d action game called \"Metal Warrior: Search for Valhalla\".\r\n",
+        "comments": [
+          {
+            "github_username": "map7",
+            "body": "Timed the talk last night, could go up to 10min, we'll see. I had a rough crowd to practice in front of (my kids)"
+          },
+          {
+            "github_username": "ponny",
+            "body": "Super keen for this!"
+          }
+        ]
+      },
+      {
+        "id": 1807154558,
+        "title": "Talk Proposal: But why does it work?",
+        "description": "Description(this will appear on youtube): Nothing is a black box! Get the confidence to dive into unfamiliar code and languages, and understand how things really work. Join me on a deep dive into gems, the Ruby source code (and maybe more!)\r\n\r\nEstimated Talk Time: 15-30 min\r\n\r\nPreferred Month to Present: July 😱\r\n\r\nPreferred Social media handles: None\r\n\r\nMugshot (will be use in the slides): https://avatars.githubusercontent.com/u/1201065",
+        "comments": [
+          {
+            "github_username": "simran-sawhney",
+            "body": "hey @rianmcguire - thanks for raising the issue mate. are you okay to do it in August if you need more time to prep, this way we would have locked in for next month ?"
+          },
+          {
+            "github_username": "simran-sawhney",
+            "body": "hey @rianmcguire moving this to next month mate for August one - let's lock that in :) "
+          },
+          {
+            "github_username": "simran-sawhney",
+            "body": "Hey @rianmcguire - let's do it mate this month. I have added Milestone to it already :) "
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2023-07-27",
+    "talks": [
+      {
+        "id": 1809022197,
+        "title": "Tips for juniors and mentors",
+        "description": "1. reach out to the community and pair up with someone (Michael)\r\n2. exercism to brush up on some ruby\r\n3. basic TDD principles - via pairing\r\n4. look at some Dojo's\r\n5. take it to next level with curses!!! winner\r\n5-10 mins\r\nready for july 26th",
+        "comments": []
+      },
+      {
+        "id": 1807364108,
+        "title": "Proposal: a production bug 27 years in the making",
+        "description": "The most robustly tested application at the company. A PR to upgrade Ruby, weeks in the The tests passed on local and on CI. No issues detected on staging or the sandbox environment. All systems green.\r\n\r\nThen the production deploy started.\r\n\r\n---\r\n\r\nA time-traveling tale of how a confluence of changes came together to cause an issue in production.\r\n\r\nDuration: 10-15 minutes\r\nMonth: July 2023\r\n\r\n\r\n\r\n",
+        "comments": [
+          {
+            "github_username": "simran-sawhney",
+            "body": "Let's do this next week on 26th July meetup!"
+          },
+          {
+            "github_username": "radar",
+            "body": "Looking forward to it!"
+          }
+        ]
+      },
+      {
+        "id": 1784401161,
+        "title": "Talk Proposal: How FHIR is tackling a wicked problem with technical, social and political solutions",
+        "description": "Description (this will appear on YouTube): \r\n\r\nThe project of interoperability in healthcare is one that would make healthcare workers' jobs easier, our healthcare industry more efficient, and improve our experiences as patients. Yet, in spite of these upsides, the project has been held back by technical difficulty, a lack of cooperation and misaligned incentives. \r\n\r\nOne of the most promising developments in this space is HL7's FHIR standard, an extensible meta-model for exchanging healthcare data. Not only does FHIR offer some novel and fascinating techniques for flexibly modelling a wide range of data, it also engages in the community-building required to help it solve real problems, and the advocacy which is seeing it gain acceptance and mandate in national and international politics.\r\n\r\nThis talk will examine how Ruby developers can make productive use of FHIR in their projects, by describing the design of FHIR and the state of the tooling available to the Ruby ecosystem. Also discussed will be the lessons we can learn from FHIR on community-building and advocacy for our own technology solutions.\r\n\r\nEstimated Talk Time: 20 minutes\r\n\r\nPreferred Month to Present: July '23\r\n\r\nPreferred Social Media Handles: matthood0@gmail.com\r\n\r\nMugshot (will be used in the slides):\r\n![mattbio](https://github.com/rubyaustralia/melbourne-ruby/assets/1885706/ebc7dec6-6fb4-4042-968e-b860ed8ef3f7)\r\n",
+        "comments": [
+          {
+            "github_username": "simran-sawhney",
+            "body": "hey @MattHood we have added **July talk** milestone for this issue , see you then!"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2021-06-24",
+    "talks": [
+      {
+        "id": 913030143,
+        "title": "Lightning talk: How to stop I18n getting complex",
+        "description": "10 minutes. \r\nIn Rails, I18n gets confusing :( I'm always trying to figure out where keys come from and what text methods return. \r\n\r\nMy team and I have done some cool stuff to keep it simple. I've never seen it done like this before, so I'd like to share it.",
+        "comments": [
+          {
+            "github_username": "optimistic-updt",
+            "body": "Hey @davich,\r\n\r\nThat sounds great.\r\nWould you be willing to share at this month's RORO (30th June)?\r\n\r\nLet me know"
+          },
+          {
+            "github_username": "davidcarlin-ap",
+            "body": "Yep, can do. Will it be in person or zoom?"
+          },
+          {
+            "github_username": "davich",
+            "body": "ha, that's also me ^^. On my work github account. Probably confusing to the casual observer."
+          },
+          {
+            "github_username": "optimistic-updt",
+            "body": "haha no problem @davich / @davidcarlin-ap.\r\nShould your talk be titled: How to stop I18n getting complex\r\n?"
+          },
+          {
+            "github_username": "davich",
+            "body": "yep, that's a descriptive title. Will the meetup be in person or zoom?"
+          },
+          {
+            "github_username": "optimistic-updt",
+            "body": "Meetup will be over Zoom @davich \r\n:)"
+          }
+        ]
+      },
+      {
+        "id": 839473136,
+        "title": "Exercism for Junior Developers",
+        "description": "Hi guys, I recently completed a bootcamp from Le Wagon. \r\n\r\nI have experienced that most bootcamp graduate lack the understanding of test driven development as well as how to conduct pair programming coding challenge. I would like to present 2 exercism exercise to showcase how to approach a problem.\r\n\r\nI am also participating in the presentation to build confidence around technical gurus.",
+        "comments": [
+          {
+            "github_username": "optimistic-updt",
+            "body": "Hey @achhetr, Thank you for reaching and well done for putting yourself out there!!\r\nWould you be keen to Present at the April RORO on the 28th (next week)?\r\n How long would your talk be?\r\n \r\n Thank you"
+          },
+          {
+            "github_username": "achhetr",
+            "body": "Thank you @CumulusGround for giving me this opportunity. I am planning to give 15 to 20 mins talk. \r\nI have two ideas which I am happy to share with young developers. \r\n1) 2 exercism exercise to showcase how to approach a problem\r\n2) How to integrate React with Rails\r\n\r\nPlease suggest which one should I go as I think they both are really important"
+          },
+          {
+            "github_username": "optimistic-updt",
+            "body": "Hey @achhetr,\r\n\r\nthey do both sound great!!\r\nbut obviously I'm mindful of having a couple of speakers on the night.\r\n\r\nHow about this:\r\nWe can do React/Ruby this time\r\nthen skip next month\r\nthen have you back in June for the exersim one.\r\n\r\nMy thought behind it is that I think a lot of bootcamp just started in March and should wrap up in June, which theoretically would give us an influx of junior, perfect target crowd for the exercism.\r\n\r\nwhat do you think?\r\n\r\nCheers\r\n"
+          },
+          {
+            "github_username": "achhetr",
+            "body": "Sounds great @CumulusGround\r\n\r\nThis will be my first presentation, have you got any tips which I can offer to the audience from React on Rails perspective"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2021-03-25",
+    "talks": [
+      {
+        "id": 839194785,
+        "title": "The Joy of Docs: Technical Writing for Developers and Engineers",
+        "description": "Hello organisers! I would like to propose a talk about technical writing. You can see the slide deck [here](https://docs.google.com/presentation/d/1somOY_01ZRgSxuAIX-RenImp9QkgytjpXwsKm91lYoo/edit?usp=sharing) if you'd like to suss it out more, but here's the gist. I can be available any Wednesday but need at least a few days' advance notice to let my D&D group know I won't be there :)\r\n\r\n## Talk Title\r\n\r\nThe Joy of Docs: Technical Writing for Developers and Engineers\r\n\r\n## Description\r\n\r\nIn this talk, I discuss communication, specifically technical writing, why it's important, and how to improve your skills. Emphasis is on identifying and empathising with your audience. The talk does not strictly cover the writing process as it is taught in schools, but rather focusses on orienting oneself towards readers' needs when writing technical documents or producing other technical writing. The information in this talk is applicable to any kind of technical writing, from commit messages to requests for comment (RFCs), as well as technical writing that is not strictly a part of a technical document (e.g., writing in an email to stakeholders about the status of development on a project). \r\n\r\n## Why It's Important\r\n\r\nBad technical writing is a huge waste of time. Every developer who's worked in the industry for any length of time has encountered vague and unhelpful documentation and seen how much time they spend trying to find information that should've been in the docs in the first place. Engineers who read RFCs and other longer-form documents may notice these documents often don't give adequate context or define terms, leading to more time spent on research rather than focussing on the tasks at hand.",
+        "comments": [
+          {
+            "github_username": "optimistic-updt",
+            "body": "Hi Dana, \r\nThank you for proposing this talk!\r\n\r\nIt sounds like a great talk and it's definitely already right at home with me :) :S\r\n\r\nHow long do you thing your talk would take? \r\nThe next RORO is next wednesday the 31st of March.\r\n\r\nWould you be keen/ready to present then?\r\n\r\nCheers\r\n"
+          },
+          {
+            "github_username": "oscaralanpierce",
+            "body": "The 31st works! The last time I gave this talk it ran about 30 minutes but I can make it longer or shorter to suit. Just let me know!"
+          },
+          {
+            "github_username": "optimistic-updt",
+            "body": "awesome, 31st it is then.\r\nWe'll be in touch with you shortly"
+          },
+          {
+            "github_username": "optimistic-updt",
+            "body": "https://youtu.be/l8pFr1y14f8"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2021-02-25",
+    "talks": [
+      {
+        "id": 813929810,
+        "title": "View Components in the Wild",
+        "description": "Just some examples of how we at [Fresho](http://fresho.com) are using [View Components](https://viewcomponent.org/) to test rails views and help us decompose the front end, it will be wild! With the better design through composability, leading to simplifying testing and more consistent front ends.\r\n\r\ninspired by https://github.com/rails-oceania/melbourne-ruby/issues/158\r\n\r\npresented from https://github.com/failure-driven/view-components-in-the-wild\r\n\r\nready for Feb 2021 - ie like tomorrow",
+        "comments": [
+          {
+            "github_username": "VanessaNimmo",
+            "body": "https://youtu.be/ISWuPcCoChw 🌄"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/sites/melbourne/lib/melbourne/data/output/events/processed/2_llm_interpretation.json
+++ b/sites/melbourne/lib/melbourne/data/output/events/processed/2_llm_interpretation.json
@@ -1,0 +1,966 @@
+[
+  {
+    "date": "2025-06-26",
+    "name": "Communicating Intent in Code with HashNotAdam",
+    "description": "HashNotAdam guides us through the art of writing code that speaks your intent and avoids common pitfalls, drawing from real Rails experience.",
+    "slug": "2025-06-26-communicating-intent-in-code-hashnotadam",
+    "talks": [
+      {
+        "title": "The Unspoken Contract: Communicating Intent Through Code",
+        "description": "Discover the secrets of writing code that communicates your intent! Learn from a real Rails bug why naming, structure, and clear boundaries matter. Ideal for devs who want their code to speak—loud and clear. Join HashNotAdam for practical tips and relatable war stories!",
+        "speakers": [
+          {
+            "name": "HashNotAdam",
+            "contact_details": {
+              "github_username": "HashNotAdam",
+              "x_handle": null,
+              "linkedin_handle": "HashNotAdam",
+              "bluesky_handle": null,
+              "mastodon_handle": null,
+              "website": null
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2025-04-24",
+    "name": "Task Runners with Michael Milewski & Rails 8 with John Sherwood",
+    "description": "Explore task runners with Michael Milewski, then get hands-on with Rails 8 in production with John Sherwood! Two practical talks to supercharge your dev workflow.",
+    "slug": "2025-04-24-task-runners-and-rails-8",
+    "talks": [
+      {
+        "title": "Make vs Justfile vs Mise",
+        "description": "Choosing the perfect task runner? Michael Milewski breaks down Make, Justfile, Mise, and more. Discover best practices, playbooks, and how far Developer Infrastructure as Code can go. Don’t miss this practical, energetic tour of modern task runners!",
+        "speakers": [
+          {
+            "name": "Michael Milewski",
+            "contact_details": {
+              "github_username": "saramic",
+              "x_handle": "saramic",
+              "linkedin_handle": "michael-milewski",
+              "bluesky_handle": null,
+              "mastodon_handle": null,
+              "website": "https://sessionize.com/michael-milewski/"
+            }
+          }
+        ]
+      },
+      {
+        "title": "rails 8 new",
+        "description": "Join John Sherwood as he shares lessons from building a production app on Rails 8! Learn the ins, outs, and happy surprises of Rails 8 with Kamal, Action Cable, Active Job, and more. Bring your questions—it’s interactive and fun!",
+        "speakers": [
+          {
+            "name": "John Sherwood",
+            "contact_details": {
+              "github_username": "ponny",
+              "x_handle": "ponny",
+              "linkedin_handle": "johnsherwooddeveloper",
+              "bluesky_handle": "ponny.dev",
+              "mastodon_handle": null,
+              "website": null
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2025-05-29",
+    "name": "Mastering Turbo Forms with Matt Hood and SQLite in Ruby with Simon Hildebrandt",
+    "description": "Join Matt Hood as he unravels Turbo form wizardry and Simon Hildebrandt delves into using SQLite as a Ruby gem. Insightful, interactive, and fun!",
+    "slug": "2025-05-29-turbo-forms-sqlite-gem",
+    "talks": [
+      {
+        "title": "How on earth do you manage forms with Turbo?",
+        "description": "Get the inside scoop on taming tricky Turbo forms! Matt Hood shares hands-on tips and fun tricks for error handling, validation, and making forms a breeze. Perfect for anyone wanting smoother Rails forms. 🚀",
+        "speakers": [
+          {
+            "name": "Matt Hood",
+            "contact_details": {
+              "github_username": "MattHood",
+              "x_handle": null,
+              "linkedin_handle": null,
+              "bluesky_handle": null,
+              "mastodon_handle": null,
+              "website": null
+            }
+          }
+        ]
+      },
+      {
+        "title": "SQLite-ruby - a whole SQL database in a gem",
+        "description": "Discover the wonders of SQLite wrapped neatly in a Ruby gem! Simon Hildebrandt introduces SQLite-ruby—fast, familiar, and a little bit magical. Bring your questions and curiosity!",
+        "speakers": [
+          {
+            "name": "Simon Hildebrandt",
+            "contact_details": {
+              "github_username": "simonhildebrandt",
+              "x_handle": null,
+              "linkedin_handle": null,
+              "bluesky_handle": null,
+              "mastodon_handle": "@apocraphilia@hachyderm.io",
+              "website": null
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2025-03-27",
+    "name": "Business Logic Objects Panel & Rack Fundamentals with Julian, Adam, Simon",
+    "description": "Dive into advanced Ruby business logic structures in a lively panel with Julian Pinzon and Adam, then get hands-on with Rack’s fundamentals with Simon Hildebrandt.",
+    "slug": "2025-03-27-logic-objects-and-rack-fundamentals",
+    "talks": [
+      {
+        "title": "Panel/Discussion/Riffing Session on Objects to encapsulate business logic",
+        "description": "Join Julian Pinzon and Adam for a lively panel on modern ways to organize business logic in Ruby apps. Discover practical tips, fresh perspectives, and get your questions answered. Don't miss this spirited session full of insight and laughs!",
+        "speakers": [
+          {
+            "name": "Julian Pinzon",
+            "contact_details": {
+              "github_username": "pinzonjulian",
+              "x_handle": null,
+              "linkedin_handle": null,
+              "bluesky_handle": null,
+              "mastodon_handle": null,
+              "website": null
+            }
+          },
+          {
+            "name": "Adam",
+            "contact_details": {
+              "github_username": "HashNotAdam",
+              "x_handle": null,
+              "linkedin_handle": null,
+              "bluesky_handle": null,
+              "mastodon_handle": null,
+              "website": null
+            }
+          }
+        ]
+      },
+      {
+        "title": "Rack Fundamentals revisited",
+        "description": "Simon Hildebrandt revisits the Rack layer under Ruby’s most popular web frameworks. Learn the core mechanics and find out when you don’t need Rails! Perfect for Rubyists looking to level-up their backend game.",
+        "speakers": [
+          {
+            "name": "Simon Hildebrandt",
+            "contact_details": {
+              "github_username": "simonhildebrandt",
+              "x_handle": null,
+              "linkedin_handle": null,
+              "bluesky_handle": null,
+              "mastodon_handle": "@apocraphilia@hachyderm.io",
+              "website": null
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2025-02-27",
+    "name": "Semantic Search and RAG with Ruby by Daniel Kaminsky",
+    "description": "Explore smart search systems in Ruby! Daniel Kaminsky breaks down embeddings, RAG, and more.",
+    "slug": "2025-02-27-semantic-search-rag-ruby",
+    "talks": [
+      {
+        "title": "Semantic Search and RAG with Ruby",
+        "description": "Curious about modern smart search? Join us as Daniel Kaminsky walks through building a powerful semantic search system with Ruby, from embeddings to Retrieval Augmented Generation. Perfect for those interested in the cutting edge of search tech!",
+        "speakers": [
+          {
+            "name": "Daniel Kaminsky",
+            "contact_details": {
+              "github_username": "dkam",
+              "x_handle": null,
+              "linkedin_handle": null,
+              "bluesky_handle": null,
+              "mastodon_handle": "@dkam@ruby.social",
+              "website": null
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2025-01-30",
+    "name": "Puma Internals with Joshua and Ruby 3.4/Rails 8 Salad by Anton",
+    "description": "Explore Puma’s secrets with Joshua and get the tasty highlights of Ruby 3.4 & Rails 8 with Anton.",
+    "slug": "2025-01-30-puma-ruby-salad",
+    "talks": [
+      {
+        "title": "The Inner Workings of Puma",
+        "description": "Ever wondered what makes Puma tick? Joshua Yeo guides us deep inside Puma’s design and advanced features. Ideal for Rubyists who want to level up their server game and understand performance secrets up close!",
+        "speakers": [
+          {
+            "name": "Joshua Yeo",
+            "contact_details": {
+              "github_username": null,
+              "x_handle": null,
+              "linkedin_handle": null,
+              "bluesky_handle": "joshuay03.bsky.social",
+              "mastodon_handle": "@joshuay03@ruby.social",
+              "website": null
+            }
+          }
+        ]
+      },
+      {
+        "title": "Ruby salad. What's fresh on the market?",
+        "description": "Join Anton for a flavourful tour of Ruby 3.4 and Rails 8’s freshest features! If you love seeing new ruby and rails goodness in action—including authentication generators and Rodauth vs Rails Auth—don’t miss this bite-sized update.",
+        "speakers": [
+          {
+            "name": "Anton Tolik",
+            "contact_details": {
+              "github_username": null,
+              "x_handle": null,
+              "linkedin_handle": null,
+              "bluesky_handle": null,
+              "mastodon_handle": null,
+              "website": null
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2024-10-24",
+    "name": "Cursor v Copilot with Ceels & Happy Ruby SAML by Pat",
+    "description": "Join us for an AI coding showdown with Ceels and dive into practical SAML magic for Ruby with Pat!",
+    "slug": "2024-10-24-cursor-v-copilot-and-happy-ruby-saml",
+    "talks": [
+      {
+        "title": "Cursor v Github Copilot: building a better data schema tool?",
+        "description": "Ceels puts Cursor and Copilot head to head! Get tips for setting up Cursor, explore its AI model options, and discover which tool fits your workflow best. Bring your questions and see these coding copilots in action!",
+        "speakers": [
+          {
+            "name": "Ceels",
+            "contact_details": {
+              "github_username": null,
+              "x_handle": null,
+              "linkedin_handle": null,
+              "bluesky_handle": null,
+              "mastodon_handle": "@ceels",
+              "website": null
+            }
+          }
+        ]
+      },
+      {
+        "title": "Happy Ruby SAML Development",
+        "description": "Pat guides you through tackling real-world SAML authentication in Ruby—no mocking, just hands-on SSO, fast Nokogiri parsing, and multi-domain setups the Covidence way. Learn how to smooth out your SAML experience!",
+        "speakers": [
+          {
+            "name": "Pat",
+            "contact_details": {
+              "github_username": "pat",
+              "x_handle": null,
+              "linkedin_handle": null,
+              "bluesky_handle": null,
+              "mastodon_handle": "@pat@hachyderm.io",
+              "website": null
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2024-11-28",
+    "name": "Hotwire Happiness with Jero Paul & Rails CurrentAttributes with Darkfishy",
+    "description": "Dive into frontend joy with Jero Paul on Hotwire, Turbo & Stimulus. Then, uncover the magic of Rails `CurrentAttributes` with Darkfishy.",
+    "slug": "2024-11-28-hotwire-and-currentattributes",
+    "talks": [
+      {
+        "title": "Turbo (Hotwire), Stimulusjs and being happy with front end development again",
+        "description": "Rediscover the joy of frontend dev! Jero Paul shares his Hotwire, Turbo, and Stimulus journey—great for anyone ready to love building apps again 🚀. Come see why modern Rails tools spark happiness!",
+        "speakers": [
+          {
+            "name": "Jero Paul",
+            "contact_details": {
+              "github_username": "jeropaul",
+              "x_handle": "gardengnome_au",
+              "linkedin_handle": null,
+              "bluesky_handle": null,
+              "mastodon_handle": null,
+              "website": null
+            }
+          }
+        ]
+      },
+      {
+        "title": "How do `CurrentAttributes` work?",
+        "description": "Ever wondered how Rails keeps track of values per request? Darkfishy explains `ActiveSupport::CurrentAttributes`, request isolation, and more in an engaging and practical talk. Perfect for Rails developers seeking backend clarity!",
+        "speakers": [
+          {
+            "name": "Darkfishy",
+            "contact_details": {
+              "github_username": "darkfishy",
+              "x_handle": null,
+              "linkedin_handle": null,
+              "bluesky_handle": null,
+              "mastodon_handle": null,
+              "website": null
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2024-09-26",
+    "name": "Understanding reload! in Rails with Darkfishy & Oaken Seeds by Julian Pinzon",
+    "description": "Discover the magic behind Rails' reload! with Darkfishy and get a fresh take on seeds and fixtures with Julian Pinzon.",
+    "slug": "2024-09-26-reload-rails-oaken-seeds",
+    "talks": [
+      {
+        "title": "How does `reload!` work?",
+        "description": "Curious about what happens when you hit `reload!` in the Rails console? Join Darkfishy as we peek under the hood and reveal how Rails reloads code, what classes are affected, and the impacts on your dev workflow. Rails magic, demystified!",
+        "speakers": [
+          {
+            "name": "darkfishy",
+            "contact_details": {
+              "github_username": "darkfishy",
+              "x_handle": "fusionfish",
+              "linkedin_handle": null,
+              "bluesky_handle": null,
+              "mastodon_handle": null,
+              "website": null
+            }
+          }
+        ]
+      },
+      {
+        "title": "Oaken - A fresh take on seeds and fixtures",
+        "description": "Step up your data game! Join Julian Pinzon as he explores Oaken, a new way to handle seeds and fixtures in Rails. Discover efficient methods, best practices, and why Oaken could become your go-to for dev data. Fresh ideas guaranteed!",
+        "speakers": [
+          {
+            "name": "Julian Pinzon",
+            "contact_details": {
+              "github_username": "pinzonjulian",
+              "x_handle": "pinzonjulian",
+              "linkedin_handle": "pinzonjulian",
+              "bluesky_handle": "pinzonjulian",
+              "mastodon_handle": "pinzonjulian",
+              "website": null
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2024-08-29",
+    "name": "Career Change Inspiration with Helen Stonehouse & Rails Engines with Chris Oliver",
+    "description": "Hear Helen Stonehouse’s journey into tech and get hands-on with Rails Engines in a fun double bill with Chris Oliver.",
+    "slug": "2024-08-29-career-change-rails-engines",
+    "talks": [
+      {
+        "title": "My Career Change - Nothing is what it seems",
+        "description": "Helen Stonehouse shares her inspiring journey into tech, filled with relatable anecdotes and encouragement to take the leap. Perfect for anyone pondering a career shift or just looking for a dose of motivation!",
+        "speakers": [
+          {
+            "name": "Helen Stonehouse",
+            "contact_details": {
+              "github_username": null,
+              "x_handle": "cinnamonbabies",
+              "linkedin_handle": "helen-stonehouse",
+              "bluesky_handle": null,
+              "mastodon_handle": null,
+              "website": null
+            }
+          }
+        ]
+      },
+      {
+        "title": "Rails Engines in 20 minutes",
+        "description": "Curious how to extend Rails? Chris Oliver will walk you through building plugins and using Engines. Join us for a practical, speedy deep dive—perfect for devs wanting to level up their Rails skills!",
+        "speakers": [
+          {
+            "name": "Chris Oliver",
+            "contact_details": {
+              "github_username": "excid3",
+              "x_handle": null,
+              "linkedin_handle": null,
+              "bluesky_handle": null,
+              "mastodon_handle": null,
+              "website": null
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2024-07-25",
+    "name": "Pinkest Pink with Dan Laush & Allyship with Nick Wolf",
+    "description": "Dive into vibrant web colors with Dan Laush and learn about being a good male ally with Nick Wolf.",
+    "slug": "2024-07-25-pinkest-pink-and-being-a-good-male-ally",
+    "talks": [
+      {
+        "title": "Pinkest Pink",
+        "description": "Explore the web’s newest, brightest colors! Dan Laush shares how our eyes see color and how we recreate vibrant realities on screens. Join us for a colorful and fun talk that will make you see web colors in a whole new light!",
+        "speakers": [
+          {
+            "name": "Dan Laush",
+            "contact_details": {
+              "github_username": "danlaush",
+              "x_handle": null,
+              "linkedin_handle": null,
+              "bluesky_handle": null,
+              "mastodon_handle": null,
+              "website": "https://danlaush.biz/"
+            }
+          }
+        ]
+      },
+      {
+        "title": "Being a Good Male Ally",
+        "description": "Nick Wolf guides us through what it means to be a supportive male ally. Join his insightful talk and foster a more inclusive, positive environment for everyone. Practical tips and genuine stories included!",
+        "speakers": [
+          {
+            "name": "Nick Wolf",
+            "contact_details": {
+              "github_username": "quintrino",
+              "x_handle": null,
+              "linkedin_handle": null,
+              "bluesky_handle": null,
+              "mastodon_handle": null,
+              "website": "https://nickwolf.com.au"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2024-06-27",
+    "name": "Rebuilding Products with Prakriti Mateti & Turbo in Laravel with Simran Sawhney",
+    "description": "Join Prakriti Mateti as she shares insights on rebuilding a large product from scratch, plus discover Turbo in Laravel with Simran Sawhney.",
+    "slug": "2024-06-27-rebuilding-products-and-turbo-in-laravel",
+    "talks": [
+      {
+        "title": "One does not simply... rebuild a product",
+        "description": "Thinking of rebuilding a big product? Join Prakriti Mateti as she takes you through the highs, lows, and lessons of rebuilding Culture Amp's second biggest platform! Great for anyone facing tough legacy code and tech debt. 🍰",
+        "speakers": [
+          {
+            "name": "Prakriti Mateti",
+            "contact_details": {
+              "github_username": null,
+              "x_handle": null,
+              "linkedin_handle": "prakritimateti",
+              "bluesky_handle": null,
+              "mastodon_handle": null,
+              "website": null
+            }
+          }
+        ]
+      },
+      {
+        "title": "Laravel, meet my friend Turbo",
+        "description": "Simran Sawhney shows how Turbo can spice up your Laravel projects! Get the scoop on Turbo, Turbo Native, and Strada, and see how they compare with Livewire. Perfect for Rubyists curious about the PHP world!",
+        "speakers": [
+          {
+            "name": "Simran Sawhney",
+            "contact_details": {
+              "github_username": "simran-sawhney",
+              "x_handle": null,
+              "linkedin_handle": null,
+              "bluesky_handle": null,
+              "mastodon_handle": null,
+              "website": null
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2024-05-30",
+    "name": "Understanding Cursors: Modern Pagination Approaches in Ruby",
+    "description": "Explore why cursor-based pagination trumps traditional pagination in Ruby—staving off data staleness and powering GraphQL and more. Perfect for anyone moving beyond standard page-by-page queries!",
+    "slug": "2024-05-30-cursors-modern-pagination-ruby",
+    "talks": [
+      {
+        "title": "Cursors: Why Pagination is Bad-gination!",
+        "description": "Don't let your data get stale! Dive into modern cursor-based pagination with Ruby and see why it's taking over GraphQL and beyond. You'll learn new ways to keep your info fresh, fast, and reliable. Pagination will never look the same again! ⚡",
+        "speakers": []
+      }
+    ]
+  },
+  {
+    "date": "2024-04-25",
+    "name": "Dissecting Rails with Anthony Chen",
+    "description": "Join Anthony Chen as he shares his dive into Rails internals—Active Support, Active Model, and more—from his learning journey. Perfect for curious Rubyists!",
+    "slug": "2024-04-25-dissecting-rails",
+    "talks": [
+      {
+        "title": "Dissecting Rails",
+        "description": "Explore Anthony Chen's hands-on takeaways from dissecting Rails internals! Learn about Active Support, Active Model, and get insights to fuel your Rails journey. Great for learners and fans of Ruby alike! 🚀",
+        "speakers": [
+          {
+            "name": "Anthony Chen",
+            "contact_details": {
+              "github_username": "friendlyantz",
+              "x_handle": "friendlyantz",
+              "linkedin_handle": null,
+              "bluesky_handle": null,
+              "mastodon_handle": null,
+              "website": null
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2024-03-28",
+    "name": "One Billion Rows in Ruby with Rian McGuire & Ruby Economics by Ponny",
+    "description": "Explore CPU crunching in Ruby with Rian McGuire and discover the economics behind the Ruby ecosystem with Ponny. Insights, techniques, and fun for every Rubyist!",
+    "slug": "2024-03-28-one-billion-rows-and-ruby-economics",
+    "talks": [
+      {
+        "title": "One Billion Rows in Ruby",
+        "description": "Find out if Ruby can tackle serious data crunching! Rian McGuire dives into the One Billion Row Challenge, optimizing Ruby to the max. Perfect for anyone who wants to push Ruby’s limits. Don’t miss this adventure in code and speed!",
+        "speakers": [
+          {
+            "name": "Rian McGuire",
+            "contact_details": {
+              "github_username": "rianmcguire",
+              "x_handle": null,
+              "linkedin_handle": null,
+              "bluesky_handle": null,
+              "mastodon_handle": null,
+              "website": null
+            }
+          }
+        ]
+      },
+      {
+        "title": "The Economics of Ruby",
+        "description": "Ruby plus economics—what's not to love? Ponny gives a rapid-fire talk on the flow of resources, incentives, and the unsung heroes powering the Ruby world. Get a fresh perspective on what keeps our community ticking!",
+        "speakers": [
+          {
+            "name": "Ponny",
+            "contact_details": {
+              "github_username": "ponny",
+              "x_handle": "ponny",
+              "linkedin_handle": null,
+              "bluesky_handle": null,
+              "mastodon_handle": null,
+              "website": null
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2024-02-22",
+    "name": "Self-hosting Rails with Saramic & Scaling Systems with Stefanus Wilfrid",
+    "description": "Explore how to host a Rails app from home with Saramic and master scaling basics of distributed systems with Stefanus Wilfrid.",
+    "slug": "2024-02-22-self-hosting-and-scaling-rails",
+    "talks": [
+      {
+        "title": "Can I host a rails app from a home server?",
+        "description": "Curious about running Rails from your own home? Saramic explores self-hosting, cost savings, DevOps fun, and why DIY deployment rocks. Come see how far you can go with bare metal! 💻",
+        "speakers": [
+          {
+            "name": "Saramic",
+            "contact_details": {
+              "github_username": "saramic",
+              "x_handle": null,
+              "linkedin_handle": null,
+              "bluesky_handle": null,
+              "mastodon_handle": null,
+              "website": null
+            }
+          }
+        ]
+      },
+      {
+        "title": "System Design & Distributed System Lightweight Concept",
+        "description": "Join Stefanus Wilfrid for a practical session on scaling your app! Learn lightweight strategies for vertical/horizontal scaling and get hands-on tips for taming distributed systems. 🚀",
+        "speakers": [
+          {
+            "name": "Stefanus Wilfrid",
+            "contact_details": {
+              "github_username": "Stefanuswilfrid",
+              "x_handle": null,
+              "linkedin_handle": null,
+              "bluesky_handle": null,
+              "mastodon_handle": null,
+              "website": null
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2024-01-25",
+    "name": "DMARC Reports with HashNotAdam & Ruby Fibers with KJ Tsanaktsidis",
+    "description": "Discover how to process DMARC reports with Action Mailbox, then take a deep dive into the internals of Ruby fibers with KJ!",
+    "slug": "2024-01-25-dmarc-action-mailbox-and-ruby-fibers",
+    "talks": [
+      {
+        "title": "Processing DMARC reports via Action Mailbox",
+        "description": "Curious about DMARC reports? See how HashNotAdam automates parsing and alerts with Action Mailbox! Perfect if you want less spam and clearer email deliverability insights—all using Ruby on Rails. Join us for email geekery made simple and fun!",
+        "speakers": [
+          {
+            "name": "HashNotAdam",
+            "contact_details": {
+              "github_username": "HashNotAdam",
+              "x_handle": null,
+              "linkedin_handle": null,
+              "bluesky_handle": null,
+              "mastodon_handle": null,
+              "website": null
+            }
+          }
+        ]
+      },
+      {
+        "title": "Something Something Fibers Something",
+        "description": "Dive into Ruby's fiber internals with KJ Tsanaktsidis! Unpack how Fiber.yield and resume work, how fibers relate to threads, and discover their awesome low-level magic. Perfect for Rubyists who love digging into the guts of the language!",
+        "speakers": [
+          {
+            "name": "KJ Tsanaktsidis",
+            "contact_details": {
+              "github_username": "KJTsanaktsidis",
+              "x_handle": null,
+              "linkedin_handle": null,
+              "bluesky_handle": null,
+              "mastodon_handle": null,
+              "website": null
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2023-11-23",
+    "name": "Developer Wisdom with Justin Towsey & Rails Engines Discussion with Anton Valkov",
+    "description": "Join Justin Towsey for lessons and wisdom from a year as a dev, then dive into Rails architecture and engines with Anton Valkov in a panel-style discussion.",
+    "slug": "2023-11-23-developer-wisdom-rails-engines",
+    "talks": [
+      {
+        "title": "Precious gems I've learned during my first dev year",
+        "description": "Reflect on a year packed with developer discoveries! Justin shares his top nuggets of wisdom and inspiring moments from his first year in tech. Perfect for new and seasoned devs alike to learn, laugh, and relate.",
+        "speakers": [
+          {
+            "name": "Justin Towsey",
+            "contact_details": {
+              "github_username": "j-tws",
+              "x_handle": null,
+              "linkedin_handle": null,
+              "bluesky_handle": null,
+              "mastodon_handle": null,
+              "website": null
+            }
+          }
+        ]
+      },
+      {
+        "title": "Rails architecture with engines work group",
+        "description": "Explore the power of Rails Engines! Anton will demo his app and kick off a group discussion on architecture best practices, sharing stories and real-world examples. Great for anyone curious about modular Rails apps.",
+        "speakers": [
+          {
+            "name": "Anton Valkov",
+            "contact_details": {
+              "github_username": "antulik",
+              "x_handle": null,
+              "linkedin_handle": null,
+              "bluesky_handle": null,
+              "mastodon_handle": null,
+              "website": null
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2023-10-26",
+    "name": "Bootcamp Project Showcase by Thomas Hoang & Env Var Insights by Michael S.",
+    "description": "Dive into full stack creativity with Thomas Hoang's bootcamp project and level-up your Rails security with Michael S.'s talk on environment variables.",
+    "slug": "2023-10-26-bootcamp-showcase-environment-variables",
+    "talks": [
+      {
+        "title": "Showcase of final project of my bootcamp with Academy Xi",
+        "description": "Celebrate creativity! Join Thomas Hoang as he presents his full stack web app—crafted from Rails and React—developed for his final Academy Xi bootcamp project. Get inspired by a real-world journey from learning to launch!",
+        "speakers": [
+          {
+            "name": "Thomas Hoang",
+            "contact_details": {
+              "github_username": null,
+              "x_handle": null,
+              "linkedin_handle": "thdev",
+              "bluesky_handle": null,
+              "mastodon_handle": null,
+              "website": "https://thdev.com.au"
+            }
+          }
+        ]
+      },
+      {
+        "title": "Thoughts on Environment Variables",
+        "description": "Learn the do's and don'ts of environment variables in Rails with Michael S.! Discover best practices for secrets, safe config storage, and tools to keep your apps secure. See real code and real solutions in this punchy lightning talk!",
+        "speakers": [
+          {
+            "name": "Michael S.",
+            "contact_details": {
+              "github_username": "saramic",
+              "x_handle": null,
+              "linkedin_handle": null,
+              "bluesky_handle": null,
+              "mastodon_handle": null,
+              "website": null
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2023-09-28",
+    "name": "Rails Forms with Anton and Power of Pair Presenting by Simran",
+    "description": "Anton shares quick insights on Rails forms, then Simran explores how pair presenting can make your talks unforgettable!",
+    "slug": "2023-09-28-rails-forms-and-pair-presenting",
+    "talks": [
+      {
+        "title": "Rails forms",
+        "description": "Join Anton for a fast-paced lightning talk on Rails forms and service objects! Perfect for anyone looking to streamline form handling in their Rails app. Short, sharp, and super practical—don’t miss it!",
+        "speakers": [
+          {
+            "name": "Anton",
+            "contact_details": {
+              "github_username": "antulik",
+              "x_handle": null,
+              "linkedin_handle": null,
+              "bluesky_handle": null,
+              "mastodon_handle": null,
+              "website": null
+            }
+          }
+        ]
+      },
+      {
+        "title": "Unleashing the Power of Pair Presenting: Elevate Your Conference Impact",
+        "description": "Simran reveals how pair presenting can transform your conference talks! Explore the benefits, pitfalls, and exciting live demos while learning to forge deeper connections and make every presentation memorable.",
+        "speakers": [
+          {
+            "name": "Simran Sawhney",
+            "contact_details": {
+              "github_username": "simran-sawhney",
+              "x_handle": null,
+              "linkedin_handle": null,
+              "bluesky_handle": null,
+              "mastodon_handle": null,
+              "website": null
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2023-08-24",
+    "name": "Game Dev with Map7 and Ruby Code Dive with Rian McGuire",
+    "description": "Hear Map7 share insights from building a 2D action game in Dragonruby, plus take a deep dive into Ruby code internals with Rian McGuire.",
+    "slug": "2023-08-24-dragonruby-and-ruby-code-dive",
+    "talks": [
+      {
+        "title": "Dragonruby: Creating the game \"Metal Warrior: Search for Valhalla\"",
+        "description": "Hear Map7 share fun stories, highlights, and hurdles from building their action-packed 2D game in Dragonruby. Aspiring game devs and curious coders—don’t miss this energetic lightning talk!",
+        "speakers": [
+          {
+            "name": "Map7",
+            "contact_details": {
+              "github_username": "map7",
+              "x_handle": null,
+              "linkedin_handle": null,
+              "bluesky_handle": null,
+              "mastodon_handle": null,
+              "website": null
+            }
+          }
+        ]
+      },
+      {
+        "title": "But why does it work?",
+        "description": "Nothing’s a black box! Rian McGuire will show you how to confidently peer into unfamiliar code and languages, exploring gems and even the Ruby source. Demystify how things really tick in this inspiring talk.",
+        "speakers": [
+          {
+            "name": "Rian McGuire",
+            "contact_details": {
+              "github_username": "rianmcguire",
+              "x_handle": null,
+              "linkedin_handle": null,
+              "bluesky_handle": null,
+              "mastodon_handle": null,
+              "website": null
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2023-07-27",
+    "name": "Guidance for Juniors, Bug Mysteries & FHIR with Michael, radar, Matt Hood",
+    "description": "Mentorship and TDD tips for juniors, unraveling a 27-year-old production bug with radar, and Matt Hood delves into FHIR's technical power in healthcare.",
+    "slug": "2023-07-27-juniors-bugs-fhir",
+    "talks": [
+      {
+        "title": "Tips for juniors and mentors",
+        "description": "Join Michael as he shares uplifting tips for juniors and mentors! Learn about pairing up in the community, brushing up Ruby with exercism, and taking your TDD and dojo skills to the next level. A quick, friendly guide for all newcomers.",
+        "speakers": [
+          {
+            "name": "Michael",
+            "contact_details": {
+              "github_username": null,
+              "x_handle": null,
+              "linkedin_handle": null,
+              "bluesky_handle": null,
+              "mastodon_handle": null,
+              "website": null
+            }
+          }
+        ]
+      },
+      {
+        "title": "A production bug 27 years in the making",
+        "description": "Get ready for a suspenseful bug hunt! radar unveils the story of a perfectly-tested app with a bug that lay dormant for 27 years. Learn from surprising production adventures. You’ll laugh, you’ll gasp, you’ll code more defensively.",
+        "speakers": [
+          {
+            "name": "radar",
+            "contact_details": {
+              "github_username": "radar",
+              "x_handle": null,
+              "linkedin_handle": null,
+              "bluesky_handle": null,
+              "mastodon_handle": null,
+              "website": null
+            }
+          }
+        ]
+      },
+      {
+        "title": "How FHIR is tackling a wicked problem with technical, social and political solutions",
+        "description": "Matt Hood explores FHIR—how it’s revolutionizing healthcare data by solving technical, social, and political challenges. Ideal for Ruby devs and anyone curious about interoperability and tech advocacy. Fascinating insights await!",
+        "speakers": [
+          {
+            "name": "Matt Hood",
+            "contact_details": {
+              "github_username": "MattHood",
+              "x_handle": null,
+              "linkedin_handle": null,
+              "bluesky_handle": null,
+              "mastodon_handle": null,
+              "website": null
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2021-06-24",
+    "name": "Simple I18n with David Carlin and Exercism for Juniors with Achhetr",
+    "description": "David Carlin shares fresh I18n simplicity tips, followed by Achhetr demoing Exercism and coding approaches for junior devs.",
+    "slug": "2021-06-24-i18n-simplicity-exercism-juniors",
+    "talks": [
+      {
+        "title": "Lightning talk: How to stop I18n getting complex",
+        "description": "Ready to stop wrestling with I18n? David Carlin reveals clever new ways to keep language logic simple in your Rails apps. Clear, concise, and unlike anything you've seen before—unlock a smoother multilingual workflow!",
+        "speakers": [
+          {
+            "name": "David Carlin",
+            "contact_details": {
+              "github_username": "davich",
+              "x_handle": null,
+              "linkedin_handle": null,
+              "bluesky_handle": null,
+              "mastodon_handle": null,
+              "website": null
+            }
+          }
+        ]
+      },
+      {
+        "title": "Exercism for Junior Developers",
+        "description": "Join Achhetr’s welcoming walkthrough of Exercism! See hands-on coding exercises and gain TDD & pair programming confidence. Perfect for new devs looking for real-world problem-solving tips and a supportive vibe.",
+        "speakers": [
+          {
+            "name": "Achhetr",
+            "contact_details": {
+              "github_username": "achhetr",
+              "x_handle": null,
+              "linkedin_handle": null,
+              "bluesky_handle": null,
+              "mastodon_handle": null,
+              "website": null
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2021-03-25",
+    "name": "The Joy of Docs: Technical Writing with Oscar Alan Pierce",
+    "description": "Join Oscar Alan Pierce as he shares practical tips for better technical writing—make your docs fun, clear, and super useful for every developer!",
+    "slug": "2021-03-25-joy-of-docs-technical-writing-oscar-alan-pierce",
+    "talks": [
+      {
+        "title": "The Joy of Docs: Technical Writing for Developers and Engineers",
+        "description": "Unlock the secrets to writing documentation that actually helps! Join Oscar Alan Pierce for a fun and insightful session on improving your technical writing and making your docs shine. You’ll never look at commit messages the same way again!",
+        "speakers": [
+          {
+            "name": "Oscar Alan Pierce",
+            "contact_details": {
+              "github_username": "oscaralanpierce",
+              "x_handle": null,
+              "linkedin_handle": null,
+              "bluesky_handle": null,
+              "mastodon_handle": null,
+              "website": null
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2021-02-25",
+    "name": "View Components in the Wild with Vanessa Nimmo",
+    "description": "See how Vanessa Nimmo and the team at Fresho use View Components to make Rails views simpler, easier to test, and more fun to build!",
+    "slug": "2021-02-25-view-components-in-the-wild",
+    "talks": [
+      {
+        "title": "View Components in the Wild",
+        "description": "See how Fresho uses View Components to make Rails testing and frontend dev wilder, more composable, and a lot more fun! Learn about decomposing UIs and writing maintainable, consistent code.",
+        "speakers": [
+          {
+            "name": "Vanessa Nimmo",
+            "contact_details": {
+              "github_username": "VanessaNimmo",
+              "x_handle": null,
+              "linkedin_handle": null,
+              "bluesky_handle": null,
+              "mastodon_handle": null,
+              "website": null
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/sites/melbourne/lib/melbourne/data/output/events/processed/3_data_in_app_domain.yml
+++ b/sites/melbourne/lib/melbourne/data/output/events/processed/3_data_in_app_domain.yml
@@ -1,0 +1,1129 @@
+---
+- uuid: 4438e22b-055c-4f37-b2c8-2eb7bd236296
+  date: '2025-06-26'
+  name: Communicating Intent in Code with HashNotAdam
+  description: HashNotAdam guides us through the art of writing code that speaks your
+    intent and avoids common pitfalls, drawing from real Rails experience.
+  slug: 2025-06-26-communicating-intent-in-code-hashnotadam
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+  - id: bb5302de-44bd-4086-8ae4-556a2bc7cb15
+    title: 'The Unspoken Contract: Communicating Intent Through Code'
+    description: Discover the secrets of writing code that communicates your intent!
+      Learn from a real Rails bug why naming, structure, and clear boundaries matter.
+      Ideal for devs who want their code to speak—loud and clear. Join HashNotAdam
+      for practical tips and relatable war stories!
+    video_url: TODO
+    speakers:
+    - name: HashNotAdam
+      contact_details:
+        github_username: HashNotAdam
+        x_handle:
+        linkedin_handle: HashNotAdam
+        bluesky_handle:
+        mastodon_handle:
+        website:
+- uuid: 1693724f-2cf7-462a-8e92-95183f80d7c4
+  date: '2025-04-24'
+  name: Task Runners with Michael Milewski & Rails 8 with John Sherwood
+  description: Explore task runners with Michael Milewski, then get hands-on with
+    Rails 8 in production with John Sherwood! Two practical talks to supercharge your
+    dev workflow.
+  slug: 2025-04-24-task-runners-and-rails-8
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+  - id: 1c98f653-d880-4097-8cd3-8cd1838ab7a5
+    title: Make vs Justfile vs Mise
+    description: Choosing the perfect task runner? Michael Milewski breaks down Make,
+      Justfile, Mise, and more. Discover best practices, playbooks, and how far Developer
+      Infrastructure as Code can go. Don’t miss this practical, energetic tour of
+      modern task runners!
+    video_url: TODO
+    speakers:
+    - name: Michael Milewski
+      contact_details:
+        github_username: saramic
+        x_handle: saramic
+        linkedin_handle: michael-milewski
+        bluesky_handle:
+        mastodon_handle:
+        website: https://sessionize.com/michael-milewski/
+  - id: e8b99459-680e-4e37-965f-8a6b1d180ee4
+    title: rails 8 new
+    description: Join John Sherwood as he shares lessons from building a production
+      app on Rails 8! Learn the ins, outs, and happy surprises of Rails 8 with Kamal,
+      Action Cable, Active Job, and more. Bring your questions—it’s interactive and
+      fun!
+    video_url: TODO
+    speakers:
+    - name: John Sherwood
+      contact_details:
+        github_username: ponny
+        x_handle: ponny
+        linkedin_handle: johnsherwooddeveloper
+        bluesky_handle: ponny.dev
+        mastodon_handle:
+        website:
+- uuid: 3e09ed96-cbb6-4089-83d1-baa3930d5dff
+  date: '2025-05-29'
+  name: Mastering Turbo Forms with Matt Hood and SQLite in Ruby with Simon Hildebrandt
+  description: Join Matt Hood as he unravels Turbo form wizardry and Simon Hildebrandt
+    delves into using SQLite as a Ruby gem. Insightful, interactive, and fun!
+  slug: 2025-05-29-turbo-forms-sqlite-gem
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+  - id: 80671f1f-3790-448b-bdcd-fae31f033d31
+    title: How on earth do you manage forms with Turbo?
+    description: "Get the inside scoop on taming tricky Turbo forms! Matt Hood shares
+      hands-on tips and fun tricks for error handling, validation, and making forms
+      a breeze. Perfect for anyone wanting smoother Rails forms. \U0001F680"
+    video_url: TODO
+    speakers:
+    - name: Matt Hood
+      contact_details:
+        github_username: MattHood
+        x_handle:
+        linkedin_handle:
+        bluesky_handle:
+        mastodon_handle:
+        website:
+  - id: 405f23a5-d49c-4e14-819e-385472aa55df
+    title: SQLite-ruby - a whole SQL database in a gem
+    description: Discover the wonders of SQLite wrapped neatly in a Ruby gem! Simon
+      Hildebrandt introduces SQLite-ruby—fast, familiar, and a little bit magical.
+      Bring your questions and curiosity!
+    video_url: TODO
+    speakers:
+    - name: Simon Hildebrandt
+      contact_details:
+        github_username: simonhildebrandt
+        x_handle:
+        linkedin_handle:
+        bluesky_handle:
+        mastodon_handle: "@apocraphilia@hachyderm.io"
+        website:
+- uuid: 5722c07e-31d3-4dbc-bee2-c833f400b6fc
+  date: '2025-03-27'
+  name: Business Logic Objects Panel & Rack Fundamentals with Julian, Adam, Simon
+  description: Dive into advanced Ruby business logic structures in a lively panel
+    with Julian Pinzon and Adam, then get hands-on with Rack’s fundamentals with Simon
+    Hildebrandt.
+  slug: 2025-03-27-logic-objects-and-rack-fundamentals
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+  - id: a82bd5c2-ea5c-48e3-8b3e-f12c88fcc403
+    title: Panel/Discussion/Riffing Session on Objects to encapsulate business logic
+    description: Join Julian Pinzon and Adam for a lively panel on modern ways to
+      organize business logic in Ruby apps. Discover practical tips, fresh perspectives,
+      and get your questions answered. Don't miss this spirited session full of insight
+      and laughs!
+    video_url: TODO
+    speakers:
+    - name: Julian Pinzon
+      contact_details:
+        github_username: pinzonjulian
+        x_handle:
+        linkedin_handle:
+        bluesky_handle:
+        mastodon_handle:
+        website:
+    - name: Adam
+      contact_details:
+        github_username: HashNotAdam
+        x_handle:
+        linkedin_handle:
+        bluesky_handle:
+        mastodon_handle:
+        website:
+  - id: 355ec943-1aa3-478f-96f6-9148e7010cdd
+    title: Rack Fundamentals revisited
+    description: Simon Hildebrandt revisits the Rack layer under Ruby’s most popular
+      web frameworks. Learn the core mechanics and find out when you don’t need Rails!
+      Perfect for Rubyists looking to level-up their backend game.
+    video_url: TODO
+    speakers:
+    - name: Simon Hildebrandt
+      contact_details:
+        github_username: simonhildebrandt
+        x_handle:
+        linkedin_handle:
+        bluesky_handle:
+        mastodon_handle: "@apocraphilia@hachyderm.io"
+        website:
+- uuid: 405f46ee-f5c5-4793-90d8-33673a903328
+  date: '2025-02-27'
+  name: Semantic Search and RAG with Ruby by Daniel Kaminsky
+  description: Explore smart search systems in Ruby! Daniel Kaminsky breaks down embeddings,
+    RAG, and more.
+  slug: 2025-02-27-semantic-search-rag-ruby
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+  - id: 24e8c8cb-ec66-45f1-be2a-06da1f1e11b3
+    title: Semantic Search and RAG with Ruby
+    description: Curious about modern smart search? Join us as Daniel Kaminsky walks
+      through building a powerful semantic search system with Ruby, from embeddings
+      to Retrieval Augmented Generation. Perfect for those interested in the cutting
+      edge of search tech!
+    video_url: TODO
+    speakers:
+    - name: Daniel Kaminsky
+      contact_details:
+        github_username: dkam
+        x_handle:
+        linkedin_handle:
+        bluesky_handle:
+        mastodon_handle: "@dkam@ruby.social"
+        website:
+- uuid: '050789d7-68cf-4c77-8155-44e670e7a7ac'
+  date: '2025-01-30'
+  name: Puma Internals with Joshua and Ruby 3.4/Rails 8 Salad by Anton
+  description: Explore Puma’s secrets with Joshua and get the tasty highlights of
+    Ruby 3.4 & Rails 8 with Anton.
+  slug: 2025-01-30-puma-ruby-salad
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+  - id: '0490599c-9a1c-4bdd-940e-8314c4605a16'
+    title: The Inner Workings of Puma
+    description: Ever wondered what makes Puma tick? Joshua Yeo guides us deep inside
+      Puma’s design and advanced features. Ideal for Rubyists who want to level up
+      their server game and understand performance secrets up close!
+    video_url: TODO
+    speakers:
+    - name: Joshua Yeo
+      contact_details:
+        github_username:
+        x_handle:
+        linkedin_handle:
+        bluesky_handle: joshuay03.bsky.social
+        mastodon_handle: "@joshuay03@ruby.social"
+        website:
+  - id: ddf7ad60-0c0f-4aa8-a55e-6ebf4249fa19
+    title: Ruby salad. What's fresh on the market?
+    description: Join Anton for a flavourful tour of Ruby 3.4 and Rails 8’s freshest
+      features! If you love seeing new ruby and rails goodness in action—including
+      authentication generators and Rodauth vs Rails Auth—don’t miss this bite-sized
+      update.
+    video_url: TODO
+    speakers:
+    - name: Anton Tolik
+      contact_details:
+        github_username:
+        x_handle:
+        linkedin_handle:
+        bluesky_handle:
+        mastodon_handle:
+        website:
+- uuid: 72262239-7a6b-4f1f-a87c-8fbd9605b578
+  date: '2024-10-24'
+  name: Cursor v Copilot with Ceels & Happy Ruby SAML by Pat
+  description: Join us for an AI coding showdown with Ceels and dive into practical
+    SAML magic for Ruby with Pat!
+  slug: 2024-10-24-cursor-v-copilot-and-happy-ruby-saml
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+  - id: ff613e61-e172-4488-b858-bc97899918ea
+    title: 'Cursor v Github Copilot: building a better data schema tool?'
+    description: Ceels puts Cursor and Copilot head to head! Get tips for setting
+      up Cursor, explore its AI model options, and discover which tool fits your workflow
+      best. Bring your questions and see these coding copilots in action!
+    video_url: TODO
+    speakers:
+    - name: Ceels
+      contact_details:
+        github_username:
+        x_handle:
+        linkedin_handle:
+        bluesky_handle:
+        mastodon_handle: "@ceels"
+        website:
+  - id: 8aa4db42-4d3e-4bb2-bde4-5710cf269264
+    title: Happy Ruby SAML Development
+    description: Pat guides you through tackling real-world SAML authentication in
+      Ruby—no mocking, just hands-on SSO, fast Nokogiri parsing, and multi-domain
+      setups the Covidence way. Learn how to smooth out your SAML experience!
+    video_url: TODO
+    speakers:
+    - name: Pat
+      contact_details:
+        github_username: pat
+        x_handle:
+        linkedin_handle:
+        bluesky_handle:
+        mastodon_handle: "@pat@hachyderm.io"
+        website:
+- uuid: e9e7267b-cf7b-4611-88ce-14718b5d8225
+  date: '2024-11-28'
+  name: Hotwire Happiness with Jero Paul & Rails CurrentAttributes with Darkfishy
+  description: Dive into frontend joy with Jero Paul on Hotwire, Turbo & Stimulus.
+    Then, uncover the magic of Rails `CurrentAttributes` with Darkfishy.
+  slug: 2024-11-28-hotwire-and-currentattributes
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+  - id: 0c5391de-34aa-40d5-ab76-617624494507
+    title: Turbo (Hotwire), Stimulusjs and being happy with front end development
+      again
+    description: "Rediscover the joy of frontend dev! Jero Paul shares his Hotwire,
+      Turbo, and Stimulus journey—great for anyone ready to love building apps again
+      \U0001F680. Come see why modern Rails tools spark happiness!"
+    video_url: TODO
+    speakers:
+    - name: Jero Paul
+      contact_details:
+        github_username: jeropaul
+        x_handle: gardengnome_au
+        linkedin_handle:
+        bluesky_handle:
+        mastodon_handle:
+        website:
+  - id: 51db52cf-ce23-4d9b-bbb4-179cecf0bf16
+    title: How do `CurrentAttributes` work?
+    description: Ever wondered how Rails keeps track of values per request? Darkfishy
+      explains `ActiveSupport::CurrentAttributes`, request isolation, and more in
+      an engaging and practical talk. Perfect for Rails developers seeking backend
+      clarity!
+    video_url: TODO
+    speakers:
+    - name: Darkfishy
+      contact_details:
+        github_username: darkfishy
+        x_handle:
+        linkedin_handle:
+        bluesky_handle:
+        mastodon_handle:
+        website:
+- uuid: b02f51ea-7d82-4bc7-b5c9-764c0baabdfd
+  date: '2024-09-26'
+  name: Understanding reload! in Rails with Darkfishy & Oaken Seeds by Julian Pinzon
+  description: Discover the magic behind Rails' reload! with Darkfishy and get a fresh
+    take on seeds and fixtures with Julian Pinzon.
+  slug: 2024-09-26-reload-rails-oaken-seeds
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+  - id: 32c4cdac-7c77-4472-9edc-72e5fffd795e
+    title: How does `reload!` work?
+    description: Curious about what happens when you hit `reload!` in the Rails console?
+      Join Darkfishy as we peek under the hood and reveal how Rails reloads code,
+      what classes are affected, and the impacts on your dev workflow. Rails magic,
+      demystified!
+    video_url: TODO
+    speakers:
+    - name: darkfishy
+      contact_details:
+        github_username: darkfishy
+        x_handle: fusionfish
+        linkedin_handle:
+        bluesky_handle:
+        mastodon_handle:
+        website:
+  - id: 0722f794-032d-4646-8114-8004546d1996
+    title: Oaken - A fresh take on seeds and fixtures
+    description: Step up your data game! Join Julian Pinzon as he explores Oaken,
+      a new way to handle seeds and fixtures in Rails. Discover efficient methods,
+      best practices, and why Oaken could become your go-to for dev data. Fresh ideas
+      guaranteed!
+    video_url: TODO
+    speakers:
+    - name: Julian Pinzon
+      contact_details:
+        github_username: pinzonjulian
+        x_handle: pinzonjulian
+        linkedin_handle: pinzonjulian
+        bluesky_handle: pinzonjulian
+        mastodon_handle: pinzonjulian
+        website:
+- uuid: a166fb19-330b-4735-bce1-5d5e9cb5ccad
+  date: '2024-08-29'
+  name: Career Change Inspiration with Helen Stonehouse & Rails Engines with Chris
+    Oliver
+  description: Hear Helen Stonehouse’s journey into tech and get hands-on with Rails
+    Engines in a fun double bill with Chris Oliver.
+  slug: 2024-08-29-career-change-rails-engines
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+  - id: bb6151cd-90f6-417d-b2e5-39e0ae0a18d6
+    title: My Career Change - Nothing is what it seems
+    description: Helen Stonehouse shares her inspiring journey into tech, filled with
+      relatable anecdotes and encouragement to take the leap. Perfect for anyone pondering
+      a career shift or just looking for a dose of motivation!
+    video_url: TODO
+    speakers:
+    - name: Helen Stonehouse
+      contact_details:
+        github_username:
+        x_handle: cinnamonbabies
+        linkedin_handle: helen-stonehouse
+        bluesky_handle:
+        mastodon_handle:
+        website:
+  - id: e3aa5ff9-41f6-4652-b090-e55f29d7186a
+    title: Rails Engines in 20 minutes
+    description: Curious how to extend Rails? Chris Oliver will walk you through building
+      plugins and using Engines. Join us for a practical, speedy deep dive—perfect
+      for devs wanting to level up their Rails skills!
+    video_url: TODO
+    speakers:
+    - name: Chris Oliver
+      contact_details:
+        github_username: excid3
+        x_handle:
+        linkedin_handle:
+        bluesky_handle:
+        mastodon_handle:
+        website:
+- uuid: 7a39e549-cf0d-402f-81f9-52e2593907cc
+  date: '2024-07-25'
+  name: Pinkest Pink with Dan Laush & Allyship with Nick Wolf
+  description: Dive into vibrant web colors with Dan Laush and learn about being a
+    good male ally with Nick Wolf.
+  slug: 2024-07-25-pinkest-pink-and-being-a-good-male-ally
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+  - id: a85a558d-af6c-4bc9-8d87-99cc13206869
+    title: Pinkest Pink
+    description: Explore the web’s newest, brightest colors! Dan Laush shares how
+      our eyes see color and how we recreate vibrant realities on screens. Join us
+      for a colorful and fun talk that will make you see web colors in a whole new
+      light!
+    video_url: TODO
+    speakers:
+    - name: Dan Laush
+      contact_details:
+        github_username: danlaush
+        x_handle:
+        linkedin_handle:
+        bluesky_handle:
+        mastodon_handle:
+        website: https://danlaush.biz/
+  - id: 75c3ba72-bd69-4d30-a4a1-da1a4cc30a06
+    title: Being a Good Male Ally
+    description: Nick Wolf guides us through what it means to be a supportive male
+      ally. Join his insightful talk and foster a more inclusive, positive environment
+      for everyone. Practical tips and genuine stories included!
+    video_url: TODO
+    speakers:
+    - name: Nick Wolf
+      contact_details:
+        github_username: quintrino
+        x_handle:
+        linkedin_handle:
+        bluesky_handle:
+        mastodon_handle:
+        website: https://nickwolf.com.au
+- uuid: 02364aaf-c011-4115-afde-66571500a38e
+  date: '2024-06-27'
+  name: Rebuilding Products with Prakriti Mateti & Turbo in Laravel with Simran Sawhney
+  description: Join Prakriti Mateti as she shares insights on rebuilding a large product
+    from scratch, plus discover Turbo in Laravel with Simran Sawhney.
+  slug: 2024-06-27-rebuilding-products-and-turbo-in-laravel
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+  - id: 63f64bd1-38f3-488a-ad50-8fa1e0af6b85
+    title: One does not simply... rebuild a product
+    description: "Thinking of rebuilding a big product? Join Prakriti Mateti as she
+      takes you through the highs, lows, and lessons of rebuilding Culture Amp's second
+      biggest platform! Great for anyone facing tough legacy code and tech debt. \U0001F370"
+    video_url: TODO
+    speakers:
+    - name: Prakriti Mateti
+      contact_details:
+        github_username:
+        x_handle:
+        linkedin_handle: prakritimateti
+        bluesky_handle:
+        mastodon_handle:
+        website:
+  - id: d1fe4bdb-b476-499e-8c07-94a08324587f
+    title: Laravel, meet my friend Turbo
+    description: Simran Sawhney shows how Turbo can spice up your Laravel projects!
+      Get the scoop on Turbo, Turbo Native, and Strada, and see how they compare with
+      Livewire. Perfect for Rubyists curious about the PHP world!
+    video_url: TODO
+    speakers:
+    - name: Simran Sawhney
+      contact_details:
+        github_username: simran-sawhney
+        x_handle:
+        linkedin_handle:
+        bluesky_handle:
+        mastodon_handle:
+        website:
+- uuid: d26df2c6-0a42-46e4-ab08-ae7308961af2
+  date: '2024-05-30'
+  name: 'Understanding Cursors: Modern Pagination Approaches in Ruby'
+  description: Explore why cursor-based pagination trumps traditional pagination in
+    Ruby—staving off data staleness and powering GraphQL and more. Perfect for anyone
+    moving beyond standard page-by-page queries!
+  slug: 2024-05-30-cursors-modern-pagination-ruby
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+  - id: 74233503-7e5c-424b-8767-ffffadff751f
+    title: 'Cursors: Why Pagination is Bad-gination!'
+    description: Don't let your data get stale! Dive into modern cursor-based pagination
+      with Ruby and see why it's taking over GraphQL and beyond. You'll learn new
+      ways to keep your info fresh, fast, and reliable. Pagination will never look
+      the same again! ⚡
+    video_url: TODO
+    speakers: []
+- uuid: 3ed4e019-6bcc-4940-866b-d94d597e79c2
+  date: '2024-04-25'
+  name: Dissecting Rails with Anthony Chen
+  description: Join Anthony Chen as he shares his dive into Rails internals—Active
+    Support, Active Model, and more—from his learning journey. Perfect for curious
+    Rubyists!
+  slug: 2024-04-25-dissecting-rails
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+  - id: 809987eb-6e08-4dec-b4ed-ef10560ffc24
+    title: Dissecting Rails
+    description: "Explore Anthony Chen's hands-on takeaways from dissecting Rails
+      internals! Learn about Active Support, Active Model, and get insights to fuel
+      your Rails journey. Great for learners and fans of Ruby alike! \U0001F680"
+    video_url: TODO
+    speakers:
+    - name: Anthony Chen
+      contact_details:
+        github_username: friendlyantz
+        x_handle: friendlyantz
+        linkedin_handle:
+        bluesky_handle:
+        mastodon_handle:
+        website:
+- uuid: d68fc115-ac10-4e82-a772-8d59a31bf6ed
+  date: '2024-03-28'
+  name: One Billion Rows in Ruby with Rian McGuire & Ruby Economics by Ponny
+  description: Explore CPU crunching in Ruby with Rian McGuire and discover the economics
+    behind the Ruby ecosystem with Ponny. Insights, techniques, and fun for every
+    Rubyist!
+  slug: 2024-03-28-one-billion-rows-and-ruby-economics
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+  - id: 70a56346-06f3-4452-bc29-1d35c69a5cb5
+    title: One Billion Rows in Ruby
+    description: Find out if Ruby can tackle serious data crunching! Rian McGuire
+      dives into the One Billion Row Challenge, optimizing Ruby to the max. Perfect
+      for anyone who wants to push Ruby’s limits. Don’t miss this adventure in code
+      and speed!
+    video_url: TODO
+    speakers:
+    - name: Rian McGuire
+      contact_details:
+        github_username: rianmcguire
+        x_handle:
+        linkedin_handle:
+        bluesky_handle:
+        mastodon_handle:
+        website:
+  - id: c04298ec-43c5-4c0c-80a6-696de64fd90b
+    title: The Economics of Ruby
+    description: Ruby plus economics—what's not to love? Ponny gives a rapid-fire
+      talk on the flow of resources, incentives, and the unsung heroes powering the
+      Ruby world. Get a fresh perspective on what keeps our community ticking!
+    video_url: TODO
+    speakers:
+    - name: Ponny
+      contact_details:
+        github_username: ponny
+        x_handle: ponny
+        linkedin_handle:
+        bluesky_handle:
+        mastodon_handle:
+        website:
+- uuid: 85a493b8-b676-4677-9ba2-83d6b3125d34
+  date: '2024-02-22'
+  name: Self-hosting Rails with Saramic & Scaling Systems with Stefanus Wilfrid
+  description: Explore how to host a Rails app from home with Saramic and master scaling
+    basics of distributed systems with Stefanus Wilfrid.
+  slug: 2024-02-22-self-hosting-and-scaling-rails
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+  - id: f3ec845d-30ba-45f0-a7a8-ec1273301581
+    title: Can I host a rails app from a home server?
+    description: "Curious about running Rails from your own home? Saramic explores
+      self-hosting, cost savings, DevOps fun, and why DIY deployment rocks. Come see
+      how far you can go with bare metal! \U0001F4BB"
+    video_url: TODO
+    speakers:
+    - name: Saramic
+      contact_details:
+        github_username: saramic
+        x_handle:
+        linkedin_handle:
+        bluesky_handle:
+        mastodon_handle:
+        website:
+  - id: ae006d1e-0d6d-4980-a665-98dcac1231b9
+    title: System Design & Distributed System Lightweight Concept
+    description: "Join Stefanus Wilfrid for a practical session on scaling your app!
+      Learn lightweight strategies for vertical/horizontal scaling and get hands-on
+      tips for taming distributed systems. \U0001F680"
+    video_url: TODO
+    speakers:
+    - name: Stefanus Wilfrid
+      contact_details:
+        github_username: Stefanuswilfrid
+        x_handle:
+        linkedin_handle:
+        bluesky_handle:
+        mastodon_handle:
+        website:
+- uuid: 3f4bc51c-83c0-43f8-a1a9-6991c46ade42
+  date: '2024-01-25'
+  name: DMARC Reports with HashNotAdam & Ruby Fibers with KJ Tsanaktsidis
+  description: Discover how to process DMARC reports with Action Mailbox, then take
+    a deep dive into the internals of Ruby fibers with KJ!
+  slug: 2024-01-25-dmarc-action-mailbox-and-ruby-fibers
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+  - id: 15d1e458-5652-4687-9a79-ba151f23edbf
+    title: Processing DMARC reports via Action Mailbox
+    description: Curious about DMARC reports? See how HashNotAdam automates parsing
+      and alerts with Action Mailbox! Perfect if you want less spam and clearer email
+      deliverability insights—all using Ruby on Rails. Join us for email geekery made
+      simple and fun!
+    video_url: TODO
+    speakers:
+    - name: HashNotAdam
+      contact_details:
+        github_username: HashNotAdam
+        x_handle:
+        linkedin_handle:
+        bluesky_handle:
+        mastodon_handle:
+        website:
+  - id: 95efaac2-63ed-4c32-9ef7-1f3192b3d08f
+    title: Something Something Fibers Something
+    description: Dive into Ruby's fiber internals with KJ Tsanaktsidis! Unpack how
+      Fiber.yield and resume work, how fibers relate to threads, and discover their
+      awesome low-level magic. Perfect for Rubyists who love digging into the guts
+      of the language!
+    video_url: TODO
+    speakers:
+    - name: KJ Tsanaktsidis
+      contact_details:
+        github_username: KJTsanaktsidis
+        x_handle:
+        linkedin_handle:
+        bluesky_handle:
+        mastodon_handle:
+        website:
+- uuid: e0a01976-53d5-47bc-9ea5-0312dd22abdb
+  date: '2023-11-23'
+  name: Developer Wisdom with Justin Towsey & Rails Engines Discussion with Anton
+    Valkov
+  description: Join Justin Towsey for lessons and wisdom from a year as a dev, then
+    dive into Rails architecture and engines with Anton Valkov in a panel-style discussion.
+  slug: 2023-11-23-developer-wisdom-rails-engines
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+  - id: b3040034-49a1-4d9d-91a3-8fe8a94a8382
+    title: Precious gems I've learned during my first dev year
+    description: Reflect on a year packed with developer discoveries! Justin shares
+      his top nuggets of wisdom and inspiring moments from his first year in tech.
+      Perfect for new and seasoned devs alike to learn, laugh, and relate.
+    video_url: TODO
+    speakers:
+    - name: Justin Towsey
+      contact_details:
+        github_username: j-tws
+        x_handle:
+        linkedin_handle:
+        bluesky_handle:
+        mastodon_handle:
+        website:
+  - id: 3fc6804f-545d-4548-9e05-569197774b81
+    title: Rails architecture with engines work group
+    description: Explore the power of Rails Engines! Anton will demo his app and kick
+      off a group discussion on architecture best practices, sharing stories and real-world
+      examples. Great for anyone curious about modular Rails apps.
+    video_url: TODO
+    speakers:
+    - name: Anton Valkov
+      contact_details:
+        github_username: antulik
+        x_handle:
+        linkedin_handle:
+        bluesky_handle:
+        mastodon_handle:
+        website:
+- uuid: d58e31c8-add3-4cc7-ad4c-05027a1edb52
+  date: '2023-10-26'
+  name: Bootcamp Project Showcase by Thomas Hoang & Env Var Insights by Michael S.
+  description: Dive into full stack creativity with Thomas Hoang's bootcamp project
+    and level-up your Rails security with Michael S.'s talk on environment variables.
+  slug: 2023-10-26-bootcamp-showcase-environment-variables
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+  - id: f9e81bae-4fb7-4029-ac76-9651fd80c6f1
+    title: Showcase of final project of my bootcamp with Academy Xi
+    description: Celebrate creativity! Join Thomas Hoang as he presents his full stack
+      web app—crafted from Rails and React—developed for his final Academy Xi bootcamp
+      project. Get inspired by a real-world journey from learning to launch!
+    video_url: TODO
+    speakers:
+    - name: Thomas Hoang
+      contact_details:
+        github_username:
+        x_handle:
+        linkedin_handle: thdev
+        bluesky_handle:
+        mastodon_handle:
+        website: https://thdev.com.au
+  - id: ba200eea-210a-435b-aae6-816beb9967d7
+    title: Thoughts on Environment Variables
+    description: Learn the do's and don'ts of environment variables in Rails with
+      Michael S.! Discover best practices for secrets, safe config storage, and tools
+      to keep your apps secure. See real code and real solutions in this punchy lightning
+      talk!
+    video_url: TODO
+    speakers:
+    - name: Michael S.
+      contact_details:
+        github_username: saramic
+        x_handle:
+        linkedin_handle:
+        bluesky_handle:
+        mastodon_handle:
+        website:
+- uuid: 654dddc4-d390-4c72-9e9d-da42a0209a24
+  date: '2023-09-28'
+  name: Rails Forms with Anton and Power of Pair Presenting by Simran
+  description: Anton shares quick insights on Rails forms, then Simran explores how
+    pair presenting can make your talks unforgettable!
+  slug: 2023-09-28-rails-forms-and-pair-presenting
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+  - id: 9e4051d6-e524-45a3-9f86-3080fc56a672
+    title: Rails forms
+    description: Join Anton for a fast-paced lightning talk on Rails forms and service
+      objects! Perfect for anyone looking to streamline form handling in their Rails
+      app. Short, sharp, and super practical—don’t miss it!
+    video_url: TODO
+    speakers:
+    - name: Anton
+      contact_details:
+        github_username: antulik
+        x_handle:
+        linkedin_handle:
+        bluesky_handle:
+        mastodon_handle:
+        website:
+  - id: f676bfb4-214e-4546-8bef-ef193a815939
+    title: 'Unleashing the Power of Pair Presenting: Elevate Your Conference Impact'
+    description: Simran reveals how pair presenting can transform your conference
+      talks! Explore the benefits, pitfalls, and exciting live demos while learning
+      to forge deeper connections and make every presentation memorable.
+    video_url: TODO
+    speakers:
+    - name: Simran Sawhney
+      contact_details:
+        github_username: simran-sawhney
+        x_handle:
+        linkedin_handle:
+        bluesky_handle:
+        mastodon_handle:
+        website:
+- uuid: cf75ed65-776e-43b5-9cc7-887f87d2ad0c
+  date: '2023-08-24'
+  name: Game Dev with Map7 and Ruby Code Dive with Rian McGuire
+  description: Hear Map7 share insights from building a 2D action game in Dragonruby,
+    plus take a deep dive into Ruby code internals with Rian McGuire.
+  slug: 2023-08-24-dragonruby-and-ruby-code-dive
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+  - id: 253957c7-9c07-4c5d-8ca1-ea57e238405d
+    title: 'Dragonruby: Creating the game "Metal Warrior: Search for Valhalla"'
+    description: Hear Map7 share fun stories, highlights, and hurdles from building
+      their action-packed 2D game in Dragonruby. Aspiring game devs and curious coders—don’t
+      miss this energetic lightning talk!
+    video_url: TODO
+    speakers:
+    - name: Map7
+      contact_details:
+        github_username: map7
+        x_handle:
+        linkedin_handle:
+        bluesky_handle:
+        mastodon_handle:
+        website:
+  - id: 133a4978-015c-4161-92bf-5314f3d94f05
+    title: But why does it work?
+    description: Nothing’s a black box! Rian McGuire will show you how to confidently
+      peer into unfamiliar code and languages, exploring gems and even the Ruby source.
+      Demystify how things really tick in this inspiring talk.
+    video_url: TODO
+    speakers:
+    - name: Rian McGuire
+      contact_details:
+        github_username: rianmcguire
+        x_handle:
+        linkedin_handle:
+        bluesky_handle:
+        mastodon_handle:
+        website:
+- uuid: 8ad866ea-07fb-46fd-8999-7eae7ebf5a99
+  date: '2023-07-27'
+  name: Guidance for Juniors, Bug Mysteries & FHIR with Michael, radar, Matt Hood
+  description: Mentorship and TDD tips for juniors, unraveling a 27-year-old production
+    bug with radar, and Matt Hood delves into FHIR's technical power in healthcare.
+  slug: 2023-07-27-juniors-bugs-fhir
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+  - id: 2d63386b-6582-4c3c-b2f4-a81e0546f35c
+    title: Tips for juniors and mentors
+    description: Join Michael as he shares uplifting tips for juniors and mentors!
+      Learn about pairing up in the community, brushing up Ruby with exercism, and
+      taking your TDD and dojo skills to the next level. A quick, friendly guide for
+      all newcomers.
+    video_url: TODO
+    speakers:
+    - name: Michael
+      contact_details:
+        github_username:
+        x_handle:
+        linkedin_handle:
+        bluesky_handle:
+        mastodon_handle:
+        website:
+  - id: f1cdbb5d-d4e0-442e-8b3d-4206b142499d
+    title: A production bug 27 years in the making
+    description: Get ready for a suspenseful bug hunt! radar unveils the story of
+      a perfectly-tested app with a bug that lay dormant for 27 years. Learn from
+      surprising production adventures. You’ll laugh, you’ll gasp, you’ll code more
+      defensively.
+    video_url: TODO
+    speakers:
+    - name: radar
+      contact_details:
+        github_username: radar
+        x_handle:
+        linkedin_handle:
+        bluesky_handle:
+        mastodon_handle:
+        website:
+  - id: 51f10894-e251-4a37-89df-87f63327f08e
+    title: How FHIR is tackling a wicked problem with technical, social and political
+      solutions
+    description: Matt Hood explores FHIR—how it’s revolutionizing healthcare data
+      by solving technical, social, and political challenges. Ideal for Ruby devs
+      and anyone curious about interoperability and tech advocacy. Fascinating insights
+      await!
+    video_url: TODO
+    speakers:
+    - name: Matt Hood
+      contact_details:
+        github_username: MattHood
+        x_handle:
+        linkedin_handle:
+        bluesky_handle:
+        mastodon_handle:
+        website:
+- uuid: cd5f7102-3430-4e44-acd4-7f0fc4da69a6
+  date: '2021-06-24'
+  name: Simple I18n with David Carlin and Exercism for Juniors with Achhetr
+  description: David Carlin shares fresh I18n simplicity tips, followed by Achhetr
+    demoing Exercism and coding approaches for junior devs.
+  slug: 2021-06-24-i18n-simplicity-exercism-juniors
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+  - id: 8719c47e-35c4-481f-8268-fcefbff3c129
+    title: 'Lightning talk: How to stop I18n getting complex'
+    description: Ready to stop wrestling with I18n? David Carlin reveals clever new
+      ways to keep language logic simple in your Rails apps. Clear, concise, and unlike
+      anything you've seen before—unlock a smoother multilingual workflow!
+    video_url: TODO
+    speakers:
+    - name: David Carlin
+      contact_details:
+        github_username: davich
+        x_handle:
+        linkedin_handle:
+        bluesky_handle:
+        mastodon_handle:
+        website:
+  - id: e4edfbf7-49b7-4824-9612-b36254b2661e
+    title: Exercism for Junior Developers
+    description: Join Achhetr’s welcoming walkthrough of Exercism! See hands-on coding
+      exercises and gain TDD & pair programming confidence. Perfect for new devs looking
+      for real-world problem-solving tips and a supportive vibe.
+    video_url: TODO
+    speakers:
+    - name: Achhetr
+      contact_details:
+        github_username: achhetr
+        x_handle:
+        linkedin_handle:
+        bluesky_handle:
+        mastodon_handle:
+        website:
+- uuid: d45f9d8d-270c-4942-9c8c-c9a7fab097c1
+  date: '2021-03-25'
+  name: 'The Joy of Docs: Technical Writing with Oscar Alan Pierce'
+  description: Join Oscar Alan Pierce as he shares practical tips for better technical
+    writing—make your docs fun, clear, and super useful for every developer!
+  slug: 2021-03-25-joy-of-docs-technical-writing-oscar-alan-pierce
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+  - id: 7d227c0b-1167-4621-9d32-d0bf6ac1c8c0
+    title: 'The Joy of Docs: Technical Writing for Developers and Engineers'
+    description: Unlock the secrets to writing documentation that actually helps!
+      Join Oscar Alan Pierce for a fun and insightful session on improving your technical
+      writing and making your docs shine. You’ll never look at commit messages the
+      same way again!
+    video_url: TODO
+    speakers:
+    - name: Oscar Alan Pierce
+      contact_details:
+        github_username: oscaralanpierce
+        x_handle:
+        linkedin_handle:
+        bluesky_handle:
+        mastodon_handle:
+        website:
+- uuid: 82d763b9-afb2-4f79-b9c4-ab08c0d4e2c0
+  date: '2021-02-25'
+  name: View Components in the Wild with Vanessa Nimmo
+  description: See how Vanessa Nimmo and the team at Fresho use View Components to
+    make Rails views simpler, easier to test, and more fun to build!
+  slug: 2021-02-25-view-components-in-the-wild
+  type: meetup
+  venue:
+    name: BOYD Community Hub
+    google_maps_url: https://maps.app.goo.gl/Tifehaitwnf2fJSq5
+    address:
+      street: 207 City Rd
+      locality: Southbank
+      postal_code: '3006'
+      region: VIC
+      country: AU
+  talks:
+  - id: 9891cde0-a3da-4baf-af84-c8a986dd34b5
+    title: View Components in the Wild
+    description: See how Fresho uses View Components to make Rails testing and frontend
+      dev wilder, more composable, and a lot more fun! Learn about decomposing UIs
+      and writing maintainable, consistent code.
+    video_url: TODO
+    speakers:
+    - name: Vanessa Nimmo
+      contact_details:
+        github_username: VanessaNimmo
+        x_handle:
+        linkedin_handle:
+        bluesky_handle:
+        mastodon_handle:
+        website:

--- a/sites/melbourne/lib/melbourne/data/output/events/raw/issues-no-milestone.json
+++ b/sites/melbourne/lib/melbourne/data/output/events/raw/issues-no-milestone.json
@@ -1,0 +1,1304 @@
+[
+  {
+    "id": 3115937914,
+    "number": 270,
+    "title": "Talk Proposal: \"In the Long Run, We're All Dead: An Economist's Guide to Tech Debt\"",
+    "description": "Description(this will appear on youtube):\n\nTech debt is a familiar concept in most organisations and has been the subject of extensive discussion regarding individual & organisational factors. However, what’s missing is a macro-economic analysis of why tech debt exists and how to combat it. This talk provides that analysis.\n\nEstimated Talk Time: 30 minutes\n\nPreferred Month to Present: July or September\n\nPreferred Social media handles: @oscaralanpierce.bsky.social\n\nMugshot (will be use in the slides): \n\n![Image](https://github.com/user-attachments/assets/88a10035-e030-4deb-8220-e3263f602281)\n",
+    "state": "open",
+    "created_at": "2025-06-04T01:29:03Z",
+    "updated_at": "2025-06-04T01:29:03Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/270",
+    "comments": []
+  },
+  {
+    "id": 3101725066,
+    "number": 269,
+    "title": "Talk Proposal: Stop hiring ruby developers",
+    "description": "Description(this will appear on youtube): Why do we put an emphasis on language over other skills when hiring? \n\nClickbait level : 8/10\n\nEstimated Talk Time: 20mins \n\nPrefered Month to Present:\n\nPreferred Social media handles:\n\nMugshot (will be use in the slides):",
+    "state": "open",
+    "created_at": "2025-05-29T23:51:25Z",
+    "updated_at": "2025-05-30T05:40:54Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/269",
+    "comments": [
+      {
+        "id": 2921288314,
+        "user": "HashNotAdam",
+        "body": "Really got me with the clickbait 🤣 ",
+        "created_at": "2025-05-30T05:40:53Z",
+        "updated_at": "2025-05-30T05:40:53Z"
+      }
+    ]
+  },
+  {
+    "id": 3101723174,
+    "number": 268,
+    "title": "Talk Proposal:  Why I don't use orms",
+    "description": "Description(this will appear on youtube): Going over the negatives of using ORMs and real life experiences of issues and the many wasted hours caused by them.\n\nEstimated Talk Time: 20 minutes \n\nPrefered Month to Present:\n\nPreferred Social media handles:\n\nMugshot (will be use in the slides):",
+    "state": "open",
+    "created_at": "2025-05-29T23:50:14Z",
+    "updated_at": "2025-06-16T00:05:10Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/268",
+    "comments": [
+      {
+        "id": 2974776272,
+        "user": "simran-sawhney",
+        "body": "Hey hey @alexanderfletcher - would you be open to present this in June on 26th ?",
+        "created_at": "2025-06-16T00:04:50Z",
+        "updated_at": "2025-06-16T00:04:50Z"
+      }
+    ]
+  },
+  {
+    "id": 3101720799,
+    "number": 267,
+    "title": "Talk Proposal: Things I don't like about Rails",
+    "description": "Description(this will appear on youtube): Going through my negative experiences as a rails outsider. \n\nEstimated Talk Time: 20 minutes \n\nPrefered Month to Present:\n\nPreferred Social media handles:\n\nMugshot (will be use in the slides):",
+    "state": "open",
+    "created_at": "2025-05-29T23:48:45Z",
+    "updated_at": "2025-05-29T23:48:45Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/267",
+    "comments": []
+  },
+  {
+    "id": 3099984895,
+    "number": 266,
+    "title": "[Talk Request] Why RubyMine?",
+    "description": "* Melbourne meetup has had regular giveaways for the RubyMine IDE\n* While not the most commonly used IDE by speakers, it does show up regularly in talks/demos\n* This request prompted tonight by speaker using RubyMine\n* Frankly IDK enough about using RubyMine in anger to know why I should consider it, so...\n* Sure, I can grab the app and try it out, but that doesn't mean I'd find out about the killer features that I may be missing out on.\n* Changing IDE for your entire workflow is not a small decision :bangbang:\n\n> [!IMPORTANT] \n> Q: I'd be most interested in seeing someone *experienced* with RubyMine as their IDE showing why they think it's worth considering a shift.\n:pray:",
+    "state": "open",
+    "created_at": "2025-05-29T11:07:02Z",
+    "updated_at": "2025-05-29T11:07:02Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/266",
+    "comments": []
+  },
+  {
+    "id": 2927976510,
+    "number": 260,
+    "title": "Requested talk: Hobbies Matter: Why the Best Developers Have Passions Beyond Code",
+    "description": "Celebrating diverse interests and their surprising impact on technical careers.",
+    "state": "open",
+    "created_at": "2025-03-18T10:33:12Z",
+    "updated_at": "2025-03-18T10:33:12Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/260",
+    "comments": []
+  },
+  {
+    "id": 2927968644,
+    "number": 259,
+    "title": "Requested talk: Debugging Burnout: A Programmer's Guide to Staying Motivated",
+    "description": "Insights on recognising and preventing burnout in tech.",
+    "state": "open",
+    "created_at": "2025-03-18T10:30:42Z",
+    "updated_at": "2025-03-18T10:30:42Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/259",
+    "comments": []
+  },
+  {
+    "id": 2927967457,
+    "number": 258,
+    "title": "Requested talk: Refactoring Your Mind: Mindfulness for Developers",
+    "description": "Using mindfulness techniques to manage stress, improve focus, and boost productivity.",
+    "state": "open",
+    "created_at": "2025-03-18T10:30:13Z",
+    "updated_at": "2025-03-18T10:30:13Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/258",
+    "comments": []
+  },
+  {
+    "id": 2927962396,
+    "number": 257,
+    "title": "Requested talk: Surviving Legacy Rails: Practical Strategies and Emotional Support",
+    "description": "An engaging look at the real struggles (and wins!) of modernizing an aging Rails codebase.",
+    "state": "closed",
+    "created_at": "2025-03-18T10:28:20Z",
+    "updated_at": "2025-03-18T10:46:37Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/257",
+    "comments": []
+  },
+  {
+    "id": 2927961113,
+    "number": 256,
+    "title": "Requested talk: Marie Kondo-ing Your Rails App: Tidying Up the Codebase",
+    "description": "How to keep your Rails app joyful, manageable, and clutter-free.",
+    "state": "open",
+    "created_at": "2025-03-18T10:27:55Z",
+    "updated_at": "2025-03-18T10:27:55Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/256",
+    "comments": []
+  },
+  {
+    "id": 2927960131,
+    "number": 255,
+    "title": "Requested talk: Rails Antipatterns: How to Write Code Your Teammates Will Secretly Hate",
+    "description": "A funny talk pointing out common Rails antipatterns, with gentle reminders of better practices.",
+    "state": "open",
+    "created_at": "2025-03-18T10:27:33Z",
+    "updated_at": "2025-03-18T10:27:33Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/255",
+    "comments": []
+  },
+  {
+    "id": 2927958198,
+    "number": 254,
+    "title": "Requested talk: I've Got 99 Problems and N+1 is Still One",
+    "description": "Funny, relatable stories about solving Rails performance issues.",
+    "state": "open",
+    "created_at": "2025-03-18T10:26:56Z",
+    "updated_at": "2025-03-18T10:26:56Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/254",
+    "comments": []
+  },
+  {
+    "id": 2927951805,
+    "number": 253,
+    "title": "Requested talk: Hidden Gems: Ruby Libraries You Didn't Know You Needed",
+    "description": "A fun tour through obscure, fascinating, and just plain weird Ruby gems.",
+    "state": "open",
+    "created_at": "2025-03-18T10:25:11Z",
+    "updated_at": "2025-03-18T10:25:11Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/253",
+    "comments": []
+  },
+  {
+    "id": 2927951026,
+    "number": 252,
+    "title": "Requested talk: Confessions of a Ruby Method Missing Addict",
+    "description": "Creative (ab)uses of Ruby’s `method_missing`",
+    "state": "open",
+    "created_at": "2025-03-18T10:24:54Z",
+    "updated_at": "2025-03-18T10:24:54Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/252",
+    "comments": []
+  },
+  {
+    "id": 2927949501,
+    "number": 251,
+    "title": "Requested talk: Things Ruby Lets Me Do That I Probably Shouldn't",
+    "description": "A humourous exploration of Ruby's flexibility and some truly questionable code.",
+    "state": "open",
+    "created_at": "2025-03-18T10:24:27Z",
+    "updated_at": "2025-03-18T10:24:27Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/251",
+    "comments": []
+  },
+  {
+    "id": 2927947832,
+    "number": 250,
+    "title": "Requested talk: Rubocop: How I Learned to Stop Worrying and Love the Linter",
+    "description": "Embrace linting as a path to inner peace.",
+    "state": "open",
+    "created_at": "2025-03-18T10:23:56Z",
+    "updated_at": "2025-03-18T10:23:56Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/250",
+    "comments": []
+  },
+  {
+    "id": 2537790749,
+    "number": 243,
+    "title": "Requested Talk: Getting started with Cursor",
+    "description": "**Description:**\r\n[Cursor](https://www.cursor.com/) is so hot right now. People rave that it far exceeds the competition (e.g. GitHub Copilot). I would love to see a walkthrough [Cursor](https://www.cursor.com/), how to configure it, which AI model to use, and a look at the pros and cons of [Cursor](https://www.cursor.com/) compared to GitHub Copilot.\r\n\r\n**Estimated Talk Time:**\r\n10–15 minutes",
+    "state": "closed",
+    "created_at": "2024-09-20T03:55:37Z",
+    "updated_at": "2024-09-29T08:33:18Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/243",
+    "comments": [
+      {
+        "id": 2376973007,
+        "user": "ceels",
+        "body": "Hey Adam and Simran, I’d like to do this talk in October",
+        "created_at": "2024-09-26T13:25:56Z",
+        "updated_at": "2024-09-26T13:25:56Z"
+      },
+      {
+        "id": 2381262618,
+        "user": "HashNotAdam",
+        "body": "Replaced by #245 ",
+        "created_at": "2024-09-29T08:33:17Z",
+        "updated_at": "2024-09-29T08:33:17Z"
+      }
+    ]
+  },
+  {
+    "id": 2431613859,
+    "number": 236,
+    "title": "Requested Talks: Back to Basics",
+    "description": "I'd love to see the following 7 short talks.\r\n\r\n- A String of good luck\r\n- An Array of options\r\n- Hash it out\r\n- Number One Integer\r\n- Ain't that the Truth\r\n- Float to the top\r\n- A Symbol of peace\r\n\r\nPresented on the basic object types in Ruby, by people that have never presented before, or co-hosted by people who've never presented. \r\n\r\n(Suggested working titles are not a requirement. 😛 ) ",
+    "state": "open",
+    "created_at": "2024-07-26T07:31:30Z",
+    "updated_at": "2024-09-25T10:29:02Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/236",
+    "comments": []
+  },
+  {
+    "id": 2329460099,
+    "number": 234,
+    "title": "Deploy Rails anywhere",
+    "description": "_haiku_\r\n\r\nCloud fatigue sets in,\r\nLonging for self-hosted peace,\r\nAlready in hand\r\n\r\n---\r\n\r\n__Title:__ Deploy Rails anywhere\r\n__About:__ Kamal - a new kid on the block, which will be part of Rails 8 soon, which makes deployment process quite easy (at least on paper). \r\nI will try to demo how-to (focusing on self hosting):\r\n- setup and deploy to clouds: aws and alike etc (may be skipped, as it is covered by many already)\r\n- deploy to home server, expose to local basic http\r\n- set up SSL, expose https to local\r\n- expose self-hosted server to web via CloudFlare\r\n- deploy to multiple servers / form a cluster (optional / not confirmed)\r\n\r\nI am reading [Kamal book (The missing manual)](https://strzibny.gumroad.com/l/kamalbook), and perhaps will do some takeaways from it not found in the docs / on the web.\r\n\r\n__Timing:__ SEP/OCT-2024\r\n\r\n>    Are you happy to have your talk published on the RubyAU YouTube channel? -> yes\r\n    Your Twitter username (if you have one) -> [@friendlyantz](https://twitter.com/friendlyantz)\r\n    Link to, or upload of, a photo of yourself that will appear in the meetup slide deck: refer https://github.com/rubyaustralia/melbourne-ruby/issues/192\r\n\r\nLength: 40min",
+    "state": "open",
+    "created_at": "2024-06-02T04:06:04Z",
+    "updated_at": "2025-04-19T07:12:40Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/234",
+    "comments": [
+      {
+        "id": 2143709497,
+        "user": "HashNotAdam",
+        "body": "Thanks, I'd really love to learn about this",
+        "created_at": "2024-06-02T05:47:04Z",
+        "updated_at": "2024-06-02T05:47:04Z"
+      },
+      {
+        "id": 2146318587,
+        "user": "ponny",
+        "body": "Also keen as!",
+        "created_at": "2024-06-03T23:56:33Z",
+        "updated_at": "2024-06-03T23:56:33Z"
+      },
+      {
+        "id": 2330514744,
+        "user": "simran-sawhney",
+        "body": "hey @friendlyantz - do you wanna go this month ???",
+        "created_at": "2024-09-05T03:15:37Z",
+        "updated_at": "2024-09-05T03:15:37Z"
+      },
+      {
+        "id": 2591244470,
+        "user": "simran-sawhney",
+        "body": "Hey @friendlyantz - do you wanna deploy rails this month ? ;) ",
+        "created_at": "2025-01-14T22:32:51Z",
+        "updated_at": "2025-01-14T22:32:51Z"
+      },
+      {
+        "id": 2816582984,
+        "user": "friendlyantz",
+        "body": "Might be keen in a few months",
+        "created_at": "2025-04-19T07:12:39Z",
+        "updated_at": "2025-04-19T07:12:39Z"
+      }
+    ]
+  },
+  {
+    "id": 2121857212,
+    "number": 225,
+    "title": "Docker development environment",
+    "description": "Not an expert by any means.\r\n\r\nNow that rails 7.1 ships by default with a production docker environment (https://github.com/rails/rails/blob/f0d433bb46ac233ec7fd7fae48f458978908d905/guides/source/7_1_release_notes.md), I got interested in trying to dockerise my development environment on the mac m1 architecture.\r\n\r\nI'm happy to talk about two alternate approaches to this specifically for mac architecture and much of the information will be cross platform applicable if anyone is interested.",
+    "state": "open",
+    "created_at": "2024-02-06T23:32:18Z",
+    "updated_at": "2025-01-14T09:18:10Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/225",
+    "comments": [
+      {
+        "id": 1931095423,
+        "user": "ZimbiX",
+        "body": "Good idea. I've done a bunch of Dockerisation work, and we had Dockerised development (and prod) environments for all our microservices at GreenSync.",
+        "created_at": "2024-02-07T01:39:56Z",
+        "updated_at": "2024-02-07T01:39:56Z"
+      },
+      {
+        "id": 2035694847,
+        "user": "simran-sawhney",
+        "body": "hey @bowdena double checking if you are still happy to present it this month at meetup ? ",
+        "created_at": "2024-04-03T22:14:42Z",
+        "updated_at": "2024-04-03T22:14:42Z"
+      },
+      {
+        "id": 2081781227,
+        "user": "simran-sawhney",
+        "body": "hey hey @bowdena - do you wanna run this as lightning talk in May 23rd ?",
+        "created_at": "2024-04-29T02:10:36Z",
+        "updated_at": "2024-04-29T02:10:36Z"
+      },
+      {
+        "id": 2589399027,
+        "user": "HashNotAdam",
+        "body": "@bowdena I'm soon to travel this path, I don't suppose you were hoping to talk soon?",
+        "created_at": "2025-01-14T09:17:59Z",
+        "updated_at": "2025-01-14T09:18:10Z"
+      }
+    ]
+  },
+  {
+    "id": 1830096814,
+    "number": 216,
+    "title": "HTMX is all you need",
+    "description": "_haiku_\r\n\r\njavascript fatigue:\r\nlonging for a hypertext\r\nalready in hand\r\n\r\n---\r\nProposing a lightning/mid talk for RORO Melbourne\r\n\r\n__Title:__ HTMX\r\n__About:__ HTMX - a new kid on the block that gives access to [AJAX](https://deploy-preview-1650--htmx.netlify.app/docs/#ajax), [CSS Transitions](https://deploy-preview-1650--htmx.netlify.app/docs/#css_transitions), [WebSockets](https://deploy-preview-1650--htmx.netlify.app/docs/#websockets) and [Server Sent Events](https://deploy-preview-1650--htmx.netlify.app/docs/#sse) directly in HTML, using [attributes](https://deploy-preview-1650--htmx.netlify.app/reference/#attributes), that could become a best friend for a back end dev who wants to have some modern WEB 2 functionality at their fingertips, without having a headache of ever-changing JS.\r\n\r\n__Timing:__ SEP-2023\r\n\r\n>    Are you happy to have your talk published on the RubyAU YouTube channel? -> yes\r\n    Your Twitter username (if you have one) -> [@friendlyantz](https://twitter.com/friendlyantz)\r\n    Link to, or upload of, a photo of yourself that will appear in the meetup slide deck: refer https://github.com/rubyaustralia/melbourne-ruby/issues/192\r\n\r\nLength: 40min",
+    "state": "open",
+    "created_at": "2023-07-31T21:49:23Z",
+    "updated_at": "2023-08-16T20:18:16Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/216",
+    "comments": []
+  },
+  {
+    "id": 1787237993,
+    "number": 211,
+    "title": "O(n) - BigO complexity of a Job Interview Algorithm",
+    "description": "Proposing a lightning/mid talk for RORO Melbourne\r\n\r\n__Title:__ BigO explained with examples\r\n__About:__ I found that a lot of companies still test your knowledge of algorithms and BigO complexity. Many will argue that these knowledge is uselees and not really required to `center a <div>`. However, it seems to be a 'secret' handshake you need to learn if you want to apply to a corporate company and be successfull at your dream job at FacePalm, Hooli, etc [aligning buttons and doing colour animations](https://www.twitch.tv/j_blow/clip/UninterestedAuspiciousPizzaFreakinStinkin-4Urg8_phIw1jbHme).\r\nI will present my takeaways and tips how to quickly estimate it. (I used [ThePrrimeagen's Aglorithm Course](https://frontendmasters.com/courses/algorithms))\r\n\r\n- BigO what it is; Time and Space; O(1), O(n), logn, n logn, n^2, n!, etc\r\n- how to roughly estimate it\r\n- examples of different algorithms and BigO estimation\r\n\r\n__Timing:__ tbc\r\n\r\n>    Are you happy to have your talk published on the RubyAU YouTube channel? -> yes\r\n    Your Twitter username (if you have one) -> [@friendlyantz](https://twitter.com/friendlyantz)\r\n    Link to, or upload of, a photo of yourself that will appear in the meetup slide deck: refer https://github.com/rubyaustralia/melbourne-ruby/issues/192\r\n\r\n(can be 10-15mins or as long as 30mins)",
+    "state": "closed",
+    "created_at": "2023-07-04T06:28:27Z",
+    "updated_at": "2024-04-14T15:21:12Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/211",
+    "comments": [
+      {
+        "id": 1627883710,
+        "user": "optimistic-updt",
+        "body": "👍🏻  Let's look at doing this in the last quarter maybe",
+        "created_at": "2023-07-10T00:36:00Z",
+        "updated_at": "2023-07-10T00:36:00Z"
+      }
+    ]
+  },
+  {
+    "id": 1770474618,
+    "number": 208,
+    "title": "How to bankrupt a company",
+    "description": "I haven't prepared the content yet, but I can give a talk about developer productivity on June meetup. Probably around 20 min.",
+    "state": "closed",
+    "created_at": "2023-06-22T22:29:06Z",
+    "updated_at": "2023-06-27T08:41:20Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/208",
+    "comments": []
+  },
+  {
+    "id": 1751206362,
+    "number": 207,
+    "title": "Tabs vs Spaces - Developer smackdown lightning talk",
+    "description": "@SelenaSmall and @saramic (Michael Milewski) what to demo and test a part of their interactive **Developer Smackdown** talk, as will be featured at [NDC Copenhagen Aug 30](https://cphdevfest.com/agenda/developer-smackdown-015a/051ortmnqer).\r\n\r\nWe want to share a ⚡️ **7 minute** _almost_ lightning talk ⚡️ version with a few of our closest friends at the RORO meetup. We are hoping for everyone to pull out a device and interact with our presentation to find out the true answers to key developer questions like:\r\n\r\n* are **Tabs** better than **Spaces** ?\r\n* are **Monoliths** better than **Microservices** ?\r\n* is **Pairing** better than **Soloing** ?\r\n* are **Branches** better than **Pushing to Trunk** ?\r\n\r\nready to go for Wed 28th June",
+    "state": "closed",
+    "created_at": "2023-06-11T02:46:42Z",
+    "updated_at": "2023-07-18T00:39:15Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/207",
+    "comments": [
+      {
+        "id": 1592130819,
+        "user": "simran-sawhney",
+        "body": "Let's do it :) ",
+        "created_at": "2023-06-14T23:43:30Z",
+        "updated_at": "2023-06-14T23:43:30Z"
+      }
+    ]
+  },
+  {
+    "id": 1730393922,
+    "number": 206,
+    "title": "The commit narrative: Penning the chronicles of your code",
+    "description": "Description(this will appear on youtube):\r\nUnveil the compelling story hidden in your code. This talk redefines the role of commit messages in software development, urging us to look beyond the 'what' and delve into the 'why' behind each code change. Through a blend of industry anecdotes, practical guidelines, and hands-on examples, we unravel how insightful commit messages foster better collaboration, streamline debugging, and guide new team members on their journey through your project's history.\r\n\r\nEstimated Talk Time:\r\n10–15 min\r\n\r\nPrefered Month to Present:\r\nMay\r\n\r\nPreferred Social media handles:\r\nHashNotAdam\r\n\r\nMugshot (will be use in the slides):\r\nhttps://www.hashnotadam.com/Adam%20Rice.jpg",
+    "state": "closed",
+    "created_at": "2023-05-29T09:14:39Z",
+    "updated_at": "2023-07-10T00:32:02Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/206",
+    "comments": [
+      {
+        "id": 1567593051,
+        "user": "simran-sawhney",
+        "body": "Let's do it @HashNotAdam for 31 May ",
+        "created_at": "2023-05-29T23:25:07Z",
+        "updated_at": "2023-05-29T23:25:54Z"
+      },
+      {
+        "id": 1567597792,
+        "user": "HashNotAdam",
+        "body": "> Let's do it @HashNotAdam for 31 May\r\n\r\nLook forward to seeing you then 😄 ",
+        "created_at": "2023-05-29T23:40:07Z",
+        "updated_at": "2023-05-29T23:40:07Z"
+      }
+    ]
+  },
+  {
+    "id": 1729887702,
+    "number": 205,
+    "title": "recent ruby conferences",
+    "description": "I have had the opportunity to attend a heap of recent ruby related conferences. In this talks I will share:\r\n\r\n1. what I have learnt\r\n2. how I got to go\r\n3. upcoming conferences\r\n4. how to get the most out of conferences\r\n\r\nthe conferences covered are:\r\n\r\n1. RubyConfTH Bangkok 2022\r\n2. RubyConfAU Melbourne 2023\r\n3. Programmable Melbourne/Sydney 2023\r\n4. TestBash Spring London | Remote 2023\r\n5. ReactMiami 2023\r\n6. RailsConf Atlanta 2023\r\n7. RubyKaigi Matsumoto 2023\r\n8. and coming soon CPP Canada, RustConf Albuquerque, ReactSummit Amsterdam | Remote, NDC Copenhagen\r\n\r\ntalk will be anywhere from 10min - 40min and include some audience interaction and games if we go for the longer version\r\n\r\ntalk slides will be here -> https://github.com/failure-driven/conferences-2023",
+    "state": "closed",
+    "created_at": "2023-05-29T02:23:00Z",
+    "updated_at": "2023-07-10T00:32:02Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/205",
+    "comments": [
+      {
+        "id": 1566508564,
+        "user": "simran-sawhney",
+        "body": "@saramic - let's do it :) ",
+        "created_at": "2023-05-29T04:18:40Z",
+        "updated_at": "2023-05-29T04:18:40Z"
+      }
+    ]
+  },
+  {
+    "id": 1680978162,
+    "number": 204,
+    "title": "Running ruby in browser using web assembly",
+    "description": "We will be using ruby to handle events on DOM\n\nTitle: \nAbout: how to integrate a hardware key (i.e. YubiKey) into ssh\n\nTiming: ready_now\n\nAre you happy to have your talk published on the RubyAU YouTube channel? -> yes\nYour Twitter username (if you have one) -> @prgrmr-yn \nLink to, or upload of, a photo of yourself that will appear in the meetup slide deck: \nTiming: 10 mins",
+    "state": "closed",
+    "created_at": "2023-04-24T10:53:31Z",
+    "updated_at": "2023-06-05T04:20:22Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/204",
+    "comments": [
+      {
+        "id": 1532323438,
+        "user": "optimistic-updt",
+        "body": "hey @prgrmr-yn , Happy to this at the may meetup in a couple of weeks?\r\n",
+        "created_at": "2023-05-03T00:51:47Z",
+        "updated_at": "2023-05-03T00:51:47Z"
+      },
+      {
+        "id": 1556333092,
+        "user": "optimistic-updt",
+        "body": "hey @prgrmr-yn, do you wnat to do this talk next week?\r\n",
+        "created_at": "2023-05-21T23:56:41Z",
+        "updated_at": "2023-05-21T23:56:41Z"
+      },
+      {
+        "id": 1574901708,
+        "user": "prgrmr-yn",
+        "body": "> hey @prgrmr-yn, do you wnat to do this talk next week?\n> \n> \n\nNot anymore sorry",
+        "created_at": "2023-06-03T12:10:09Z",
+        "updated_at": "2023-06-03T12:10:09Z"
+      }
+    ]
+  },
+  {
+    "id": 1677734699,
+    "number": 203,
+    "title": "2FA your SSH",
+    "description": "Proposing a lightning talk for RORO Melbourne\r\n\r\n__Title:__ 2FA your SSH\r\n__About:__ how to integrate a hardware key (i.e. YubiKey) into ssh\r\n\r\n__Timing:__ ready_now\r\n\r\n>    Are you happy to have your talk published on the RubyAU YouTube channel? -> yes\r\n    Your Twitter username (if you have one) -> [@friendlyantz](https://twitter.com/friendlyantz)\r\n    Link to, or upload of, a photo of yourself that will appear in the meetup slide deck: refer https://github.com/rubyaustralia/melbourne-ruby/issues/192\r\n\r\n__Timing:__ 10 mins",
+    "state": "closed",
+    "created_at": "2023-04-21T03:42:53Z",
+    "updated_at": "2023-07-04T06:20:23Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/203",
+    "comments": []
+  },
+  {
+    "id": 1647439283,
+    "number": 202,
+    "title": "The State of OpenTelemetry for Ruby Developers ",
+    "description": "Proposing a lightning/mid talk for RORO Melbourne\r\n\r\n__Title:__ OpenTelemetry \r\n__About:__ my takeaways from toying with OpenTelemetry, and how it compares to DataDog, etc\r\n\r\n__Timing:__ mid-2023\r\n\r\n>    Are you happy to have your talk published on the RubyAU YouTube channel? -> yes\r\n    Your Twitter username (if you have one) -> [@friendlyantz](https://twitter.com/friendlyantz)\r\n    Link to, or upload of, a photo of yourself that will appear in the meetup slide deck: refer https://github.com/rubyaustralia/melbourne-ruby/issues/192\r\n\r\n__Timing:__ 10-20mins",
+    "state": "closed",
+    "created_at": "2023-03-30T11:34:21Z",
+    "updated_at": "2023-07-18T00:39:15Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/202",
+    "comments": [
+      {
+        "id": 1571136889,
+        "user": "simran-sawhney",
+        "body": "Hey @friendlyantz - this is so cool and will be helpful for alot of devs in community. let's do it for June 28th ? ",
+        "created_at": "2023-06-01T00:25:13Z",
+        "updated_at": "2023-06-01T00:25:13Z"
+      },
+      {
+        "id": 1583610302,
+        "user": "friendlyantz",
+        "body": "Hey @simran-sawhney, let me see what I can prepare... unless we have other volunteers/talk, I can slap something together",
+        "created_at": "2023-06-08T23:44:13Z",
+        "updated_at": "2023-06-08T23:44:13Z"
+      },
+      {
+        "id": 1592131976,
+        "user": "simran-sawhney",
+        "body": "Hey @friendlyantz - I was bit away from system but yeh let me confirm you in a day or 2, as we always are looking for new ones. But hey, now we know we have solid talk coming up anyways, so yeh let's be on stand by. I would try to encourage new speakers and see if we can find something.",
+        "created_at": "2023-06-14T23:45:38Z",
+        "updated_at": "2023-06-14T23:45:38Z"
+      },
+      {
+        "id": 1592219770,
+        "user": "friendlyantz",
+        "body": "No worries, will put on hold. Keep me posted\n",
+        "created_at": "2023-06-15T01:52:49Z",
+        "updated_at": "2023-06-15T01:52:49Z"
+      },
+      {
+        "id": 1596309808,
+        "user": "simran-sawhney",
+        "body": "Alright @friendlyantz - let's rock and roll this one, maybe it's meant for you this time mate. I think most of the speakers are quite busy shopping these days lol so not 100% confirmations coming through.\r\n\r\nlet me know if you are good with this so we can book this one in. ",
+        "created_at": "2023-06-18T23:49:33Z",
+        "updated_at": "2023-06-18T23:49:33Z"
+      },
+      {
+        "id": 1599935575,
+        "user": "simran-sawhney",
+        "body": "Hey @friendlyantz - can we lock this in then so I can attach this through the event details ?\r\nCheers,",
+        "created_at": "2023-06-21T01:29:29Z",
+        "updated_at": "2023-06-21T01:29:29Z"
+      }
+    ]
+  },
+  {
+    "id": 1610712245,
+    "number": 201,
+    "title": "Talk Proposal: Roll Your Own Ruby Type Checking Library",
+    "description": "The idea for this talk stems from a conversation I had with a colleague, about the ways that one could implement Sorbet's type annotations. I've been experimenting with some different techniques, and think it could be interesting material for a talk at the Ruby meetup.\r\n\r\nI've already written up some of this as a blog post, using meta-programming to annotate functions. So the talk would be partly based on that, and partly a follow up that explores some of the challenges of type checking in a language as dynamic as Ruby.\r\n\r\nLength: 20-30 mins",
+    "state": "closed",
+    "created_at": "2023-03-06T05:45:25Z",
+    "updated_at": "2023-07-10T00:31:58Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/201",
+    "comments": [
+      {
+        "id": 1474626939,
+        "user": "optimistic-updt",
+        "body": "hey Tristan,\r\n\r\nWould you be ok for April meetup?",
+        "created_at": "2023-03-18T02:40:20Z",
+        "updated_at": "2023-03-18T02:40:20Z"
+      },
+      {
+        "id": 1474739545,
+        "user": "tristanpenman",
+        "body": "April works well for me.",
+        "created_at": "2023-03-18T06:00:47Z",
+        "updated_at": "2023-03-18T06:00:47Z"
+      },
+      {
+        "id": 1475085585,
+        "user": "optimistic-updt",
+        "body": "Done\r\n",
+        "created_at": "2023-03-19T03:17:58Z",
+        "updated_at": "2023-03-19T03:17:58Z"
+      },
+      {
+        "id": 1480365040,
+        "user": "optimistic-updt",
+        "body": "@tristanpenman, Can I keep you in the back pocket for next week? 😓 \r\nMy planned main speaker is currently not answering me...\r\nLet me know if that is an option and I ll aim to confirm by tomorrow.\r\n\r\nCheeers",
+        "created_at": "2023-03-22T23:03:55Z",
+        "updated_at": "2023-03-22T23:03:55Z"
+      },
+      {
+        "id": 1480369297,
+        "user": "tristanpenman",
+        "body": "Hey @optimistic-updt, I can make that work 👍 ",
+        "created_at": "2023-03-22T23:08:10Z",
+        "updated_at": "2023-03-22T23:08:10Z"
+      },
+      {
+        "id": 1480379646,
+        "user": "optimistic-updt",
+        "body": "Ok i ll confirm tomorrow.\nCheers",
+        "created_at": "2023-03-22T23:23:57Z",
+        "updated_at": "2023-03-22T23:23:57Z"
+      },
+      {
+        "id": 1482120810,
+        "user": "optimistic-updt",
+        "body": "hey @tristanpenman , my other speaker came through, let's schdule you for april as originally arranged",
+        "created_at": "2023-03-24T01:18:04Z",
+        "updated_at": "2023-03-24T01:18:04Z"
+      },
+      {
+        "id": 1482178331,
+        "user": "tristanpenman",
+        "body": "All good 👍 ",
+        "created_at": "2023-03-24T02:52:56Z",
+        "updated_at": "2023-03-24T02:52:56Z"
+      },
+      {
+        "id": 1518630872,
+        "user": "optimistic-updt",
+        "body": "Hey @tristanpenman , still good to do it this week?\r\nCan you possibly do it on the Thursday? I might have to move the meetup to Thursday as I'm having problem securing a room.\r\n\r\nCheers",
+        "created_at": "2023-04-22T12:09:09Z",
+        "updated_at": "2023-04-22T12:09:09Z"
+      },
+      {
+        "id": 1518636276,
+        "user": "tristanpenman",
+        "body": "No worries. Content is all good to go, and either Wednesday or Thursday are okay for me.",
+        "created_at": "2023-04-22T12:29:44Z",
+        "updated_at": "2023-04-22T12:29:44Z"
+      },
+      {
+        "id": 1522524256,
+        "user": "tristanpenman",
+        "body": "Hi @optimistic-updt is this going ahead tonight (Wednesday) or moving to Thursday?",
+        "created_at": "2023-04-25T23:02:28Z",
+        "updated_at": "2023-04-25T23:02:28Z"
+      },
+      {
+        "id": 1522554659,
+        "user": "optimistic-updt",
+        "body": "hi Tristan,\r\nDespite best effort to reschedule this week or on the same day.\r\nMy only earliest possibiliy is next Friday 5th of May.\r\n\r\nWould you still be able to attend and speak?\r\n\r\nSorry about the mess around",
+        "created_at": "2023-04-25T23:52:17Z",
+        "updated_at": "2023-04-25T23:52:17Z"
+      },
+      {
+        "id": 1522557126,
+        "user": "tristanpenman",
+        "body": "Totally understand the challenges with meetup admin, having been in that spot a few times myself 😬\r\n\r\n5th of May works for me, so I'll keep that free in my calendar.",
+        "created_at": "2023-04-25T23:56:33Z",
+        "updated_at": "2023-04-25T23:56:33Z"
+      },
+      {
+        "id": 1522564616,
+        "user": "optimistic-updt",
+        "body": "Let's lock it in 🔥 \r\n",
+        "created_at": "2023-04-26T00:05:19Z",
+        "updated_at": "2023-04-26T00:05:19Z"
+      }
+    ]
+  },
+  {
+    "id": 1610139619,
+    "number": 200,
+    "title": "Queuing Theory and how to Sidekiq 🥋(can be 10mins or as long as 30mins)",
+    "description": "Proposing a lightning talk for RORO Melbourne\r\n\r\n__Title:__ Queuing Theory and how to Sidekiq 🥋\r\n__About:__ my takeaways from studying a bit of queuing theory and reading the book [\"Sidekiq in Practice\" by Nate Bercopec](https://nateberk.gumroad.com/l/sidekiqinpractice)  \r\n- intro into queuing theory, cost analysis\r\n- how sidekiq works and best practices\r\n\r\n__Timing:__ Nov-2023\r\n\r\n>    Are you happy to have your talk published on the RubyAU YouTube channel? -> yes\r\n    Your Twitter username (if you have one) -> [@friendlyantz](https://twitter.com/friendlyantz)\r\n    Link to, or upload of, a photo of yourself that will appear in the meetup slide deck: refer https://github.com/rubyaustralia/melbourne-ruby/issues/192\r\n\r\n(can be 10-15mins or as long as 30mins)",
+    "state": "open",
+    "created_at": "2023-03-05T10:28:05Z",
+    "updated_at": "2023-07-04T06:24:12Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/200",
+    "comments": [
+      {
+        "id": 1563826252,
+        "user": "simran-sawhney",
+        "body": "hey @friendlyantz - do you want to do this talk this next week, 31st of May ?",
+        "created_at": "2023-05-26T05:22:48Z",
+        "updated_at": "2023-05-26T05:22:48Z"
+      },
+      {
+        "id": 1619575171,
+        "user": "friendlyantz",
+        "body": "will put a break on it. will see if I will be able to land a Ruby Job and dive deeper into it.\r\nCurrently focused on generic stuff like bigO, algorythms, and smashing the interview live-coding challanges -might do a talk on that",
+        "created_at": "2023-07-04T06:24:12Z",
+        "updated_at": "2023-07-04T06:24:12Z"
+      }
+    ]
+  },
+  {
+    "id": 1557399755,
+    "number": 199,
+    "title": "Talk Proposal: Ten minutes with YJIT",
+    "description": "Description(this will appear on youtube):\r\nAs of Ruby 3.2, YJIT is no longer experimental, so I decided to try it out in production and see what happens. This intends to be a surface-level look at what YJIT can do without getting too deep into how it works. Aka, \"YJIT—The Fun Bits\"\r\n\r\nEstimated Talk Time:\r\n10–15 min\r\n\r\nPrefered Month to Present:\r\nAnytime\r\n\r\nPreferred Social media handles:\r\nHashNotAdam\r\n\r\nMugshot (will be use in the slides):\r\nhttps://www.hashnotadam.com/Adam%20Rice.jpg",
+    "state": "closed",
+    "created_at": "2023-01-25T23:19:17Z",
+    "updated_at": "2023-07-10T00:31:58Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/199",
+    "comments": [
+      {
+        "id": 1474626867,
+        "user": "optimistic-updt",
+        "body": "Adam! boss!\r\n\r\nYou did come up with a talk!\r\nWould you be ok for April?",
+        "created_at": "2023-03-18T02:39:59Z",
+        "updated_at": "2023-03-18T02:39:59Z"
+      },
+      {
+        "id": 1480363608,
+        "user": "optimistic-updt",
+        "body": "Actually, wanna do it next week? @HashNotAdam ",
+        "created_at": "2023-03-22T23:02:17Z",
+        "updated_at": "2023-03-22T23:02:17Z"
+      },
+      {
+        "id": 1482180920,
+        "user": "HashNotAdam",
+        "body": "@optimistic-updt I could do April; do you know when that is? I'm pretty snowed rn, but I can see that light",
+        "created_at": "2023-03-24T02:57:40Z",
+        "updated_at": "2023-03-24T02:57:40Z"
+      },
+      {
+        "id": 1518630796,
+        "user": "optimistic-updt",
+        "body": "Hey @HashNotAdam, still good to do it this week?\r\nCan you possibly do it on the Thursday? I might have to move the meetup to Thursday as I'm having problem securing a room.\r\n\r\nCheers",
+        "created_at": "2023-04-22T12:08:48Z",
+        "updated_at": "2023-04-22T12:08:48Z"
+      },
+      {
+        "id": 1519205930,
+        "user": "HashNotAdam",
+        "body": "Yeah, no stress",
+        "created_at": "2023-04-24T00:15:45Z",
+        "updated_at": "2023-04-24T00:15:45Z"
+      },
+      {
+        "id": 1556350727,
+        "user": "HashNotAdam",
+        "body": "@optimistic-updt is there a recording of this?",
+        "created_at": "2023-05-22T00:33:01Z",
+        "updated_at": "2023-05-22T00:33:01Z"
+      },
+      {
+        "id": 1556353210,
+        "user": "optimistic-updt",
+        "body": "will come up\n\nOn Mon, May 22, 2023 at 10:33 AM Adam Rice ***@***.***> wrote:\n\n> @optimistic-updt <https://github.com/optimistic-updt> is there a\n> recording of this?\n>\n> —\n> Reply to this email directly, view it on GitHub\n> <https://github.com/rubyaustralia/melbourne-ruby/issues/199#issuecomment-1556350727>,\n> or unsubscribe\n> <https://github.com/notifications/unsubscribe-auth/AOKNIA5BJF7HSOQMAPXTUV3XHKX4PANCNFSM6AAAAAAUG4S5DM>\n> .\n> You are receiving this because you were mentioned.Message ID:\n> ***@***.***>\n>\n\n\n-- \n\n*Kevin Garcia-Fernandez*\n*Front-End Developer* | SMART STUDIO\n*Portofolio <https://www.kevgarcia.fyi/> || *\n*Linkedin <https://www.linkedin.com/in/kevgarciaf/> || Github\n***@***.***\n(AU) +61 (0)421.822.631\n",
+        "created_at": "2023-05-22T00:38:58Z",
+        "updated_at": "2023-05-22T00:38:58Z"
+      }
+    ]
+  },
+  {
+    "id": 1556079769,
+    "number": 198,
+    "title": "Talk proposal: cookies_same_site_protection :lax or :strict which is better and why?",
+    "description": "From Rails 6.1, Rails.application.config.action_dispatch.cookies_same_site_protection has been added to it. It has :lax, :strict and :none as options.\r\nI believe :lax is as good as :strict in the context of security and in top of this :lax provides good user experience. I would like someone to discuss on this matter. And explain that :lax is not less in protecting cross-origin request than :strict. \r\n\r\nI have read in medium: https://lilyreile.medium.com/rails-6-1-new-framework-defaults-what-they-do-and-how-to-safely-uncomment-them-c546b70f0c5e and couple of other sites about it.",
+    "state": "open",
+    "created_at": "2023-01-25T05:29:56Z",
+    "updated_at": "2023-05-23T01:29:35Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/198",
+    "comments": [
+      {
+        "id": 1474626239,
+        "user": "optimistic-updt",
+        "body": "Hey There,\r\nDo you have an idea of how long this talk would be?\r\n\r\nif 10min or less, would you be interested in doing it this month on the 29th?\r\nelse if more than 10min would you be interested to do it in April meetup?",
+        "created_at": "2023-03-18T02:36:49Z",
+        "updated_at": "2023-03-18T02:36:49Z"
+      },
+      {
+        "id": 1480363272,
+        "user": "optimistic-updt",
+        "body": "@Dipesh8Bhatta \r\n",
+        "created_at": "2023-03-22T23:01:46Z",
+        "updated_at": "2023-03-22T23:01:46Z"
+      },
+      {
+        "id": 1556332425,
+        "user": "optimistic-updt",
+        "body": "@Dipesh8Bhatta heya, any news on that? would you want to do it next week?",
+        "created_at": "2023-05-21T23:53:32Z",
+        "updated_at": "2023-05-22T00:23:52Z"
+      },
+      {
+        "id": 1558338796,
+        "user": "Dipesh8Bhatta",
+        "body": "Hi Kevin,\n\nI am out of the country at the moment.\n\nI will reach you out when I am back.\n\nThanks,\nDipesh\n\nOn Mon, May 22, 2023, 9:53 AM Kevin Garcia-F ***@***.***>\nwrote:\n\n> @Dipesh8Bhatta <https://github.com/Dipesh8Bhatta> heya, any news on that?\n> whould you want to do it next week?\n>\n> —\n> Reply to this email directly, view it on GitHub\n> <https://github.com/rubyaustralia/melbourne-ruby/issues/198#issuecomment-1556332425>,\n> or unsubscribe\n> <https://github.com/notifications/unsubscribe-auth/ABSFSQP4H6QZJHPXJ7OVLPLXHKTINANCNFSM6AAAAAAUF46VHY>\n> .\n> You are receiving this because you were mentioned.Message ID:\n> ***@***.***>\n>\n",
+        "created_at": "2023-05-23T01:29:34Z",
+        "updated_at": "2023-05-23T01:29:34Z"
+      }
+    ]
+  },
+  {
+    "id": 1555777766,
+    "number": 197,
+    "title": "Talk Proposal: Running an App in 30 Languages by John Sherwood",
+    "description": null,
+    "state": "closed",
+    "created_at": "2023-01-24T22:44:38Z",
+    "updated_at": "2023-03-18T02:38:28Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/197",
+    "comments": []
+  },
+  {
+    "id": 1554365201,
+    "number": 196,
+    "title": "Talk Proposal: Present like a pro",
+    "description": "Description(this will appear on youtube): \r\n\r\n> So you want to -- or have to -- present a talk. On stage. In front of people. \r\n> Don't panic! In this talk, we will discuss why talks are great for both teaching and learning, some of the basic do's and don'ts, and an easy 8 step plan to get you writing your (first? next?!) presentation. \r\n\r\nEstimated Talk Time: 25-45 minutes (super flexible!)\r\n\r\nPreferred Month to Present: Jan 2023\r\n\r\nPreferred Social media handles: glasnt@cloudisland.nz\r\n\r\nMugshot (will be use in the slides): https://glasnt.com/katie.png\r\n",
+    "state": "closed",
+    "created_at": "2023-01-24T05:52:54Z",
+    "updated_at": "2023-03-18T02:38:28Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/196",
+    "comments": []
+  },
+  {
+    "id": 1553941600,
+    "number": 195,
+    "title": "Idea: Ruby Conf debrief",
+    "description": null,
+    "state": "closed",
+    "created_at": "2023-01-23T22:37:24Z",
+    "updated_at": "2023-03-22T23:01:31Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/195",
+    "comments": []
+  },
+  {
+    "id": 1449172460,
+    "number": 194,
+    "title": "Talk Proposal: Data Encryption in Rails: Why Isn't Everyone Doing It?",
+    "description": "As a number of recent high profile breaches have demonstrated, a lot of our deeply personal information is regularly getting compromised.  Encrypting data is an extremely effective way of protecting that data, but it's still not a universal practice.  It's easy to assume that it's just overworked developers or myopic management, but there are some real challenges to encrypting data that doom many applications to have to store their data in plain text, when they'd really prefer not to.\r\n\r\nI'll talk about data encryption and why it's not as widely used as it really should be, and a new open source project I've started to address some of the challenges of usable data encryption, which happens to have an ActiveRecord plugin as its first public client.\r\n\r\nFormat: I can pare it down to 15 minutes if necessary, but 30-45 minutes gives me a chance to really get the message across.  With more time I can give the pure Rubyists a thrill, too, with more of a deep dive into the underlying technology (such as the joys of tying Ruby and Rust together).\r\n\r\nAvailability: I can't make it to meetups in the school holidays, so either this coming meetup (Nov) or it'll have to push out to Feb (or later).",
+    "state": "closed",
+    "created_at": "2022-11-15T05:04:42Z",
+    "updated_at": "2023-03-18T02:38:24Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/194",
+    "comments": [
+      {
+        "id": 1319602083,
+        "user": "optimistic-updt",
+        "body": "This sounds amazing.\nLet me see what i can do with current propose talks.\nDefinitely want to allow the full 45min.\nAre you tentatively available 29th of November?\nRoro might fall on that day this month due to room availability ",
+        "created_at": "2022-11-18T06:26:36Z",
+        "updated_at": "2022-11-18T06:26:36Z"
+      },
+      {
+        "id": 1321430825,
+        "user": "mpalmer",
+        "body": "I can do the 29th.",
+        "created_at": "2022-11-21T03:56:30Z",
+        "updated_at": "2022-11-21T03:56:30Z"
+      },
+      {
+        "id": 1326880686,
+        "user": "optimistic-updt",
+        "body": "We are on Matt.\r\n\r\nGet it ready for next Tuesday :) Let's finish the year big :) ",
+        "created_at": "2022-11-24T22:57:00Z",
+        "updated_at": "2022-11-24T22:57:00Z"
+      },
+      {
+        "id": 1326895371,
+        "user": "mpalmer",
+        "body": "Roger dodger.  Slide manufacturing is now commencing.",
+        "created_at": "2022-11-24T23:45:01Z",
+        "updated_at": "2022-11-24T23:45:01Z"
+      },
+      {
+        "id": 1328774631,
+        "user": "optimistic-updt",
+        "body": "hey @mpalmer,\r\nAre you all good for tomorrow?\r\n\r\nVenue is at the dock, are you across that?\r\nCome at 5.50 if you want to test your setup\r\n\r\nI need a mugshot from you for my slides\r\n\r\nYou'll prob go second,\r\nAre you on the Ruby slack? if so under waht name.\r\n\r\nDo you have a twitter handle?\r\n\r\n",
+        "created_at": "2022-11-28T09:25:57Z",
+        "updated_at": "2022-11-28T09:25:57Z"
+      },
+      {
+        "id": 1329843999,
+        "user": "mpalmer",
+        "body": "I am ready to rawk for tonight.  I'm aware of the venue change, and will be there early to test my setup.  Will my GitHub profile pic work, or do you need something higher res?  I'm not on the Ruby slack, but my Twitter handle is @tobermatt.",
+        "created_at": "2022-11-28T22:35:50Z",
+        "updated_at": "2022-11-28T22:35:50Z"
+      },
+      {
+        "id": 1329907268,
+        "user": "optimistic-updt",
+        "body": "I can roll with that ;) \r\nsee you tonight\r\n",
+        "created_at": "2022-11-29T00:10:41Z",
+        "updated_at": "2022-11-29T00:10:41Z"
+      }
+    ]
+  },
+  {
+    "id": 1431072754,
+    "number": 193,
+    "title": "Talk Proposal: Testing in Production: there is a better way",
+    "description": "A journey on how to do refactoring in mission-critical production code with confidence.",
+    "state": "closed",
+    "created_at": "2022-11-01T08:36:20Z",
+    "updated_at": "2023-03-18T02:38:24Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/193",
+    "comments": [
+      {
+        "id": 1319598233,
+        "user": "optimistic-updt",
+        "body": "Hey legend,\nHow long do you reckon this talk would be?\nWould upu be good to give it on tuesday the 29th instead of the 30th of November?",
+        "created_at": "2022-11-18T06:20:19Z",
+        "updated_at": "2022-11-18T06:20:19Z"
+      },
+      {
+        "id": 1321399596,
+        "user": "igas",
+        "body": "Hey, 40-45 minutes I think. 29th works for me 👍🏼 ",
+        "created_at": "2022-11-21T03:15:51Z",
+        "updated_at": "2022-11-21T03:15:51Z"
+      },
+      {
+        "id": 1326881035,
+        "user": "optimistic-updt",
+        "body": "Let's DO IT.\r\nYou re on for next Tuesday 👍🏻 ",
+        "created_at": "2022-11-24T22:57:46Z",
+        "updated_at": "2022-11-24T22:57:46Z"
+      },
+      {
+        "id": 1328215759,
+        "user": "igas",
+        "body": "@optimistic-updt 👍🏼  I updated the title 🙏🏼 ",
+        "created_at": "2022-11-27T10:27:49Z",
+        "updated_at": "2022-11-27T10:27:49Z"
+      },
+      {
+        "id": 1328799807,
+        "user": "optimistic-updt",
+        "body": "@igas \r\nAre you still G for tomorrow?\r\n\r\nDo you have a mugshot I can use?\r\n\r\nCheers\r\n",
+        "created_at": "2022-11-28T09:48:59Z",
+        "updated_at": "2022-11-28T09:48:59Z"
+      }
+    ]
+  },
+  {
+    "id": 1430660850,
+    "number": 192,
+    "title": "Awesome GitHub Landing Page",
+    "description": "Proposing a lightning talk for RORO Melbourne!\r\n\r\n- Titile(WIP): Awesome GitHub Profile / Landing Page\r\n- About: how to make your main gitHub profile page look fantastic 🚂 , and perhaps touch on elementary bits of TDD and static website framework used on GitHub(Jekyll) \r\n- Timing: Nov-2022\r\n- Are you happy to have your talk published on the RubyAU YouTube channel? -> `yes`\r\n- Your Twitter username (if you have one) -> [@friendlyantz](https://twitter.com/friendlyantz)\r\n- Link to, or upload of, a photo of yourself that will appear in the meetup slide deck: \r\n\r\n<img src=\"https://user-images.githubusercontent.com/70934030/199131724-7f0f0a0f-0a42-4e96-9df7-0f763c3ff2b9.png\" alt=\"drawing\" width=\"200\"/>\r\n\r\nTalk might be as short as 5mins or as long as 15\r\n",
+    "state": "closed",
+    "created_at": "2022-11-01T00:17:37Z",
+    "updated_at": "2023-07-10T00:31:54Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/192",
+    "comments": [
+      {
+        "id": 1297847317,
+        "user": "friendlyantz",
+        "body": "also, might copy-paste a template for creating new issues from Sydney RoRO",
+        "created_at": "2022-11-01T00:21:32Z",
+        "updated_at": "2022-11-01T00:21:32Z"
+      },
+      {
+        "id": 1319600390,
+        "user": "optimistic-updt",
+        "body": "Heya,\nStill keen?\nDo you think you can do it on the 29th instead of 30th?\nIt looks like this month roro is going to have to he on the tuesday",
+        "created_at": "2022-11-18T06:23:44Z",
+        "updated_at": "2022-11-18T06:23:44Z"
+      },
+      {
+        "id": 1320848129,
+        "user": "friendlyantz",
+        "body": "Absolutely!",
+        "created_at": "2022-11-19T09:53:33Z",
+        "updated_at": "2022-11-19T09:53:33Z"
+      },
+      {
+        "id": 1326879996,
+        "user": "optimistic-updt",
+        "body": "Anton, I'm going to save you for next year.\r\nFirst in Jan 25th.\r\nCan you do that?\r\nI would like to finish the year with two big talks\r\nlet me know if ok",
+        "created_at": "2022-11-24T22:54:42Z",
+        "updated_at": "2022-11-24T22:54:42Z"
+      },
+      {
+        "id": 1328831068,
+        "user": "friendlyantz",
+        "body": "Yeah, that's no worries at all! ",
+        "created_at": "2022-11-28T10:12:59Z",
+        "updated_at": "2022-11-28T10:12:59Z"
+      },
+      {
+        "id": 1383883238,
+        "user": "optimistic-updt",
+        "body": "Anton,\r\n\r\nAre you still good to do this talk this month?",
+        "created_at": "2023-01-16T11:11:05Z",
+        "updated_at": "2023-01-16T11:11:05Z"
+      },
+      {
+        "id": 1401020082,
+        "user": "friendlyantz",
+        "body": "Nope, sry, I am away at the moment, coming back to VIC in Feb ",
+        "created_at": "2023-01-23T21:37:19Z",
+        "updated_at": "2023-01-23T21:37:19Z"
+      },
+      {
+        "id": 1474625888,
+        "user": "optimistic-updt",
+        "body": "Anton, would you be keen to do this one this month or you'd rather do the queuing theory?",
+        "created_at": "2023-03-18T02:34:55Z",
+        "updated_at": "2023-03-18T02:34:55Z"
+      },
+      {
+        "id": 1477770540,
+        "user": "friendlyantz",
+        "body": "hey Kevin, I need some time to get queuing theory presso ready. This is ok as a warm-up before / in between main speakers.\r\n",
+        "created_at": "2023-03-21T12:40:26Z",
+        "updated_at": "2023-03-21T12:41:27Z"
+      },
+      {
+        "id": 1480362831,
+        "user": "optimistic-updt",
+        "body": "yes you'd probably go first :)\r\n",
+        "created_at": "2023-03-22T23:01:08Z",
+        "updated_at": "2023-03-22T23:01:08Z"
+      }
+    ]
+  },
+  {
+    "id": 1423795951,
+    "number": 191,
+    "title": "Talk Proposal: Black hat Ruby - Creating a malicious Ruby Gem",
+    "description": "Ruby gives us a lot of sharp knives, but what if someone was to use them not for good, but for evil?\r\nThis talk will be an exploration into what malicious Ruby gems can do and how bad actors disguise themselves by looking at some examples and creating one live.\r\n\r\nDuration: no idea 😂 I can check back in closer to the meetup date with how deep I'll be going\r\n\r\n---\r\n\r\n**Disclaimer: Please do not intentionally create malicious gems with the intent to distribute them! This should be treated as an educational piece on why we should all be wary around open-source code.**",
+    "state": "closed",
+    "created_at": "2022-10-26T10:27:45Z",
+    "updated_at": "2023-07-10T00:31:54Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/191",
+    "comments": [
+      {
+        "id": 1319599342,
+        "user": "optimistic-updt",
+        "body": "Heya Dave,\n\nHow long do you reckon your talk would be?\nSounds like a 20-30 min talk to me? Minimum.\n\nI know you were worried about the clash with react meetup.\nWould you be possibly able to do it on the 29th instead?\n\nIt looks like roro is going to have to move due to room availability ",
+        "created_at": "2022-11-18T06:22:13Z",
+        "updated_at": "2022-11-18T06:22:13Z"
+      },
+      {
+        "id": 1320731711,
+        "user": "daveallie",
+        "body": "Yeah, 30 minutes would be good. Either the 29th or 30th are both fine, if the clash happens I'll attend RORO",
+        "created_at": "2022-11-19T01:35:45Z",
+        "updated_at": "2022-11-19T01:35:45Z"
+      },
+      {
+        "id": 1326880399,
+        "user": "optimistic-updt",
+        "body": "Dave,\r\nI'm going to save you for next year, ok?\r\nJan 25th.\r\n\r\nok for you?",
+        "created_at": "2022-11-24T22:55:48Z",
+        "updated_at": "2022-11-24T22:55:48Z"
+      },
+      {
+        "id": 1326885679,
+        "user": "daveallie",
+        "body": "I'll be up in Brisbane on the 25th of Jan, but will back back down for Feb!",
+        "created_at": "2022-11-24T23:10:26Z",
+        "updated_at": "2022-11-24T23:10:26Z"
+      },
+      {
+        "id": 1474625751,
+        "user": "optimistic-updt",
+        "body": "Heya Dave, Would you be keen to present this one this month on the 29th?",
+        "created_at": "2023-03-18T02:34:13Z",
+        "updated_at": "2023-03-18T02:34:13Z"
+      },
+      {
+        "id": 1480380412,
+        "user": "daveallie",
+        "body": "Yeah perfect, sounds good!",
+        "created_at": "2023-03-22T23:25:10Z",
+        "updated_at": "2023-03-22T23:25:10Z"
+      }
+    ]
+  },
+  {
+    "id": 1421393072,
+    "number": 190,
+    "title": "Experiments in Sidekiq - dual writes, transaction outbox, maybe sagas and loading bars",
+    "description": "Sometimes the best way to understand something, is to build a demo. This is a presentation on a number of demos around Sidekiq and background jobs as well as a sort of methodology I use to make my demo projects somewhat repeatable.\r\n\r\nA look at\r\n* sidekiq\r\n* \"Dual Write\" problem\r\n* Outbox pattern\r\n* Saga pattern - if we have time\r\n\r\nbasically https://github.com/failure-driven/experimental-methods-in-sidekiq/blob/main/PRESENTATION.md\r\n\r\nReady for October 2023",
+    "state": "closed",
+    "created_at": "2022-10-24T20:22:19Z",
+    "updated_at": "2022-10-28T03:29:50Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/190",
+    "comments": []
+  },
+  {
+    "id": 1390128305,
+    "number": 189,
+    "title": "Update README with changes in roles and sponsors",
+    "description": null,
+    "state": "closed",
+    "created_at": "2022-09-29T01:35:20Z",
+    "updated_at": "2022-10-26T23:02:00Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/pull/189",
+    "comments": []
+  },
+  {
+    "id": 1080354541,
+    "number": 188,
+    "title": "Talk Proposal: Github Copilot by Ceels (TBD)",
+    "description": "@ceels \r\n(no pressure, just writing it here for my notes :))",
+    "state": "closed",
+    "created_at": "2021-12-14T22:24:01Z",
+    "updated_at": "2022-04-22T14:03:47Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/188",
+    "comments": []
+  },
+  {
+    "id": 1060684753,
+    "number": 187,
+    "title": "writing that first rails test",
+    "description": "so you have done a boot camp or have created a rails project that you want to take it to the next level. Everyone is telling you that testing is a good thing but how and where do you get started?\r\n\r\nin this intro to testing, I will take you through the following steps\r\n\r\n1. add rspec/capybara for testing\r\n2. write an \"End to End\" (E2E) \"user flow\" through your app, retrospectively\r\n3. split the flow into a series of \"arrange\" (When) and \"assert\" (Then) statements\r\n4. make it run in the browser\r\n5. abstract the page with a Page Object Model using site_prism gem\r\n6. delete all that cruft that you may have scaffolded up in the first place\r\n7. touch on how to incrementally build out your app driving it with tests using \"pending\" statements",
+    "state": "closed",
+    "created_at": "2021-11-22T23:21:20Z",
+    "updated_at": "2022-09-27T00:09:22Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/187",
+    "comments": [
+      {
+        "id": 977545654,
+        "user": "saramic",
+        "body": "follow along at https://github.com/saramic/rails-shorts-demo",
+        "created_at": "2021-11-24T05:27:44Z",
+        "updated_at": "2021-11-24T05:27:44Z"
+      }
+    ]
+  },
+  {
+    "id": 1060679182,
+    "number": 186,
+    "title": "Talk Proposal: Becoming an Engineering Manager - Nadia Vu",
+    "description": null,
+    "state": "open",
+    "created_at": "2021-11-22T23:12:12Z",
+    "updated_at": "2023-07-04T06:21:26Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/186",
+    "comments": [
+      {
+        "id": 976022613,
+        "user": "optimistic-updt",
+        "body": "@nadiavu",
+        "created_at": "2021-11-23T00:07:35Z",
+        "updated_at": "2021-11-23T00:07:35Z"
+      },
+      {
+        "id": 1480360391,
+        "user": "optimistic-updt",
+        "body": "Hi Nadia,\r\nWould you want to do this anytime this year?\r\n",
+        "created_at": "2023-03-22T22:57:24Z",
+        "updated_at": "2023-03-22T22:57:24Z"
+      },
+      {
+        "id": 1528932021,
+        "user": "HashNotAdam",
+        "body": "I would be super keen to see this talk",
+        "created_at": "2023-04-30T03:50:59Z",
+        "updated_at": "2023-04-30T03:50:59Z"
+      },
+      {
+        "id": 1619570508,
+        "user": "friendlyantz",
+        "body": "I would be keen too! get amogst @nadiavu\r\n",
+        "created_at": "2023-07-04T06:20:53Z",
+        "updated_at": "2023-07-04T06:21:26Z"
+      }
+    ]
+  },
+  {
+    "id": 1052638106,
+    "number": 185,
+    "title": "Talk proposal: Image compression. How it works, why you need it",
+    "description": "It seems to be unclear who should be the expert on image compression. Engineers or designers? We all want fast sites and most of a site's download is in images, so this is fertile ground for optimisation.\r\n\r\nI'd like to dig into different image formats and what they're good for. A bit of a deep dive into how some of the formats work (DCT, chroma-subsampling etc). And the future of images on the web.\r\n\r\n20 minutes, maybe?",
+    "state": "closed",
+    "created_at": "2021-11-13T09:22:12Z",
+    "updated_at": "2022-09-27T00:09:19Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/185",
+    "comments": [
+      {
+        "id": 975995312,
+        "user": "optimistic-updt",
+        "body": "I'll pencil you in for Jan",
+        "created_at": "2021-11-22T23:10:07Z",
+        "updated_at": "2021-11-22T23:10:07Z"
+      }
+    ]
+  },
+  {
+    "id": 1034531568,
+    "number": 184,
+    "title": "=> Interview (coming soon)",
+    "description": null,
+    "state": "closed",
+    "created_at": "2021-10-24T22:38:12Z",
+    "updated_at": "2023-11-26T06:53:45Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/184",
+    "comments": []
+  },
+  {
+    "id": 1034531197,
+    "number": 183,
+    "title": "=> Talk Proposal: <my-talk-template> Template",
+    "description": "Description(this will appear on youtube):\n\nEstimated Talk Time:\n\nPrefered Month to Present:\n\nPreferred Social media handles:\n\nMugshot (will be use in the slides):",
+    "state": "open",
+    "created_at": "2021-10-24T22:36:01Z",
+    "updated_at": "2022-11-18T06:31:58Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/183",
+    "comments": []
+  },
+  {
+    "id": 1034530165,
+    "number": 182,
+    "title": "Lighting talk on RUBY AGM",
+    "description": "By Nick Wolf",
+    "state": "closed",
+    "created_at": "2021-10-24T22:29:58Z",
+    "updated_at": "2021-11-22T23:06:13Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/182",
+    "comments": []
+  },
+  {
+    "id": 1022254641,
+    "number": 181,
+    "title": "Talk proposal: nailing your live coding job interview in Ruby",
+    "description": "Live coding over Zoom has become a popular way to do technical interviews with job candidates these days. This talk would cover how I would handle this kind of interview, with tips and suggestions.\r\n\r\nI'm happy to give this talk at the next RoRo (27 Oct, 2021) if that's convenient.",
+    "state": "closed",
+    "created_at": "2021-10-11T04:41:00Z",
+    "updated_at": "2021-11-22T23:06:13Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/181",
+    "comments": [
+      {
+        "id": 939748721,
+        "user": "optimistic-updt",
+        "body": "@tomdalling That's sounds awesome!! you could run a mini interview as par of the talk 😛\r\nNot a problem, let me know how much time you need.",
+        "created_at": "2021-10-11T07:10:02Z",
+        "updated_at": "2021-10-11T07:10:02Z"
+      },
+      {
+        "id": 939757395,
+        "user": "tomdalling",
+        "body": "I'm thinking it would be about 15-20 minutes. Does that suit? And yes, I was thinking about doing some audience participation and getting someone to interview me live, if anyone is game enough.",
+        "created_at": "2021-10-11T07:20:36Z",
+        "updated_at": "2021-10-11T07:20:36Z"
+      },
+      {
+        "id": 950406028,
+        "user": "optimistic-updt",
+        "body": "👍🏻 ",
+        "created_at": "2021-10-24T22:27:58Z",
+        "updated_at": "2021-10-24T22:27:58Z"
+      }
+    ]
+  },
+  {
+    "id": 1008037574,
+    "number": 180,
+    "title": "==> Open Discussion Topics <==",
+    "description": "At times, instead of watching a talk, we like to discuss ideas in an open conversation format.\r\nIf you would love to debate a subject or hear more from the crowd about a certain topic, add it by leaving a comment below.\r\n\r\nTopic discussion to talk in a open forum style at the RORO melboune",
+    "state": "closed",
+    "created_at": "2021-09-27T11:32:49Z",
+    "updated_at": "2025-03-18T10:34:13Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/180",
+    "comments": [
+      {
+        "id": 993256511,
+        "user": "optimistic-updt",
+        "body": "How to nurture your career as a Ruby Developer",
+        "created_at": "2021-12-14T08:03:13Z",
+        "updated_at": "2021-12-14T08:03:13Z"
+      }
+    ]
+  },
+  {
+    "id": 1008033004,
+    "number": 179,
+    "title": "Rails Active Model",
+    "description": "Julian Pizon",
+    "state": "closed",
+    "created_at": "2021-09-27T11:27:01Z",
+    "updated_at": "2021-10-24T22:28:49Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/179",
+    "comments": []
+  },
+  {
+    "id": 1008032424,
+    "number": 178,
+    "title": "Stripe integration",
+    "description": "Akash Chhetri",
+    "state": "closed",
+    "created_at": "2021-09-27T11:26:17Z",
+    "updated_at": "2021-10-24T22:28:49Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/178",
+    "comments": []
+  },
+  {
+    "id": 1006954010,
+    "number": 177,
+    "title": "stop rubocop fix-up commits - like ever!",
+    "description": "- We all love rubocop ❤️ - _to keep consistent ruby styling_\r\n    - Like Nick Wolf told us back in https://www.youtube.com/watch?v=PkZTlvLmpvw\r\n- but breaking the build for a missing comma costs companies millions 💵\r\n- why not be the developer who builds tools for other developers and prevents this from 📣 \"ever happening again! like ever!\"\r\n\r\nIn this 5-minute lightning talk, I will show you how to safeguard your team from ever wasting time on broken builds due to a rubocop linting failure - almost ever. I will also include some real examples of how cool rubocop is as well as how to get started in a legacy codebase adding rubocop for the first time. Finishing it off with another \"classic fixup commit\" you can fix for your team!\r\n\r\n5 minutes\r\nOK for Sep 2021",
+    "state": "closed",
+    "created_at": "2021-09-25T04:13:32Z",
+    "updated_at": "2021-10-24T22:28:49Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/177",
+    "comments": []
+  },
+  {
+    "id": 934083020,
+    "number": 176,
+    "title": "Data pipelines in Rails and Postgres",
+    "description": "the nuts and bolts of how to insert and upsert data quickly in Rails and Postgresql using both the gem `activerecord-import` and Rails 6 new `insert_all` and `upsert_all` command. Also some thoughts on how to do data processing in Ruby using the chaining `then` to compose data transformations.\r\n\r\nfollow my progress on the talk here -> https://github.com/failure-driven/data-pipelines-in-ruby\r\n\r\nshould be good to go for July meetup",
+    "state": "closed",
+    "created_at": "2021-06-30T20:04:44Z",
+    "updated_at": "2021-09-27T11:25:10Z",
+    "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/176",
+    "comments": [
+      {
+        "id": 874038926,
+        "user": "optimistic-updt",
+        "body": "Awesome @saramic, looking forward to hear about it.\r\nI guess I'll ask you later on long you think this one will be  :)",
+        "created_at": "2021-07-05T11:27:45Z",
+        "updated_at": "2021-07-05T11:27:45Z"
+      },
+      {
+        "id": 886265967,
+        "user": "optimistic-updt",
+        "body": "Hey @saramic,\r\nConfirming you are all still good to present at this wednesday RORO ? \r\n:) \r\nSee you then\r\n",
+        "created_at": "2021-07-25T22:23:17Z",
+        "updated_at": "2021-07-25T22:23:17Z"
+      },
+      {
+        "id": 886267923,
+        "user": "saramic",
+        "body": "yeah all good - probably be ~30min but will try to cut it shorter if I can",
+        "created_at": "2021-07-25T22:41:35Z",
+        "updated_at": "2021-07-25T22:41:35Z"
+      },
+      {
+        "id": 886269139,
+        "user": "optimistic-updt",
+        "body": "no stress.\r\nI'm still looking for a lighting talk contender !",
+        "created_at": "2021-07-25T22:51:57Z",
+        "updated_at": "2021-07-25T22:51:57Z"
+      }
+    ]
+  }
+]

--- a/sites/melbourne/lib/melbourne/data/output/events/raw/issues.json
+++ b/sites/melbourne/lib/melbourne/data/output/events/raw/issues.json
@@ -1,0 +1,1240 @@
+{
+  "Ruby Melbourne June 2025": [
+    {
+      "id": 3171733200,
+      "number": 271,
+      "title": "Talk Proposal: The Unspoken Contract: Communicating Intent Through Code",
+      "description": "### Description(this will appear on youtube):\nCode doesn’t just tell computers what to do—it tells future developers what you meant. In this talk, we’ll explore how a simple change in a Ruby on Rails app—replacing `image_tag` with `vite_image_tag`—unintentionally broke a core abstraction, causing a baffling `JSON::NestingError`.\n\nThis bug wasn’t just about tools like Vite or Active Storage—it was a symptom of a deeper problem: intent wasn’t communicated clearly in the code.\n\nWe’ll explore the idea of unspoken contracts in software—those invisible lines where systems, assumptions, and mental models meet. Through real-world examples, you’ll learn how to:\n\n- Recognise where intent gets lost in translation\n- Communicate purpose through naming, structure, and boundaries\n- Leave better breadcrumbs for your teammates and future self\n\nWhether you're refactoring, reviewing, or just trying to be less confusing, this talk will help you write code that speaks more clearly—even when you're not there to explain it.\n\n### Estimated Talk Time:\n30 minutes\n\n### Prefered Month to Present:\nJune 2025\n\n### Preferred Social media handles:\nGitHub: HashNotAdam\nLinkedIn: HashNotAdam\n\n### Mugshot (will be use in the slides):\nSame as from our host slides",
+      "state": "open",
+      "created_at": "2025-06-24T12:03:32Z",
+      "updated_at": "2025-06-25T06:43:17Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/271",
+      "comments": []
+    }
+  ],
+  "Ruby Melbourne April 2025": [
+    {
+      "id": 2990963355,
+      "number": 265,
+      "title": "Talk Proposal: Make vs Justfile vs Mise",
+      "description": "Description(this will appear on youtube):\n\n## Make vs Justfile vs Mise - _choose your task runner_\n\nOverview the some task runners like **Make**, **Justfile** and **Mise** - may even take a look at [**xc**](https://xcfile.dev/) then delve into the hard questions:\n\n- why a task runner is important?\n- which ones to use and when?\n- some gotchas?\n- some common playbooks!\n- `DIAC` - Developer Infrastructure as Code - how far can we take this?\n\npresentation will be documented here: https://github.com/failure-driven/make-just-dev-runners\n\nEstimated Talk Time: `18 min`\n\nPreferred Month to Present: **April 2025**\n\nPreferred Social media handles:\n- https://github.com/saramic\n- https://x.com/saramic\n- https://www.linkedin.com/in/michael-milewski/\n- https://sessionize.com/michael-milewski/\n\nMugshot (will be use in the slides): \n\n<img src=\"https://failure-driven.com/images/michael_milewski_profile_20190421_large.jpg\" width=\"320\">\n",
+      "state": "closed",
+      "created_at": "2025-04-13T03:40:07Z",
+      "updated_at": "2025-05-20T02:41:13Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/265",
+      "comments": []
+    },
+    {
+      "id": 2915946094,
+      "number": 249,
+      "title": "Talk Proposal: rails 8 new",
+      "description": "Description(this will appear on youtube):\nI started a new app on January 1st using Rails 8.  It's running in production in a farily Rails 8 way with a few changes which I can explain.  Using Kamal, Action Cable, Action Text, Active Job, etc.  I'm probably doing a few things wrong too so people can correct me (Yay!  Interactive talk via Cunningham's law!)\n\nMainly I'm just really happy with Rails 8 and want to gush about it ❤ \n\nEstimated Talk Time: Can be adjusted.  Perhaps 15-30 mins.\n\nPrefered Month to Present: April\n\nPreferred Social media handles:\nhttps://www.linkedin.com/in/johnsherwooddeveloper/\nhttps://bsky.app/profile/ponny.dev\nhttps://x.com/ponny\n\nMugshot (will be use in the slides):\n![Image](https://github.com/user-attachments/assets/12913521-9b09-4f5f-82ca-b131b35a7998)",
+      "state": "closed",
+      "created_at": "2025-03-13T05:53:57Z",
+      "updated_at": "2025-05-20T02:41:31Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/249",
+      "comments": [
+        {
+          "id": 2764849583,
+          "user": "simran-sawhney",
+          "body": "Hey @ponny I have added this as 20 minutes talk for 24th April",
+          "created_at": "2025-03-31T00:44:22Z",
+          "updated_at": "2025-03-31T00:44:22Z"
+        }
+      ]
+    }
+  ],
+  "Ruby Melbourne May 2025": [
+    {
+      "id": 2950841633,
+      "number": 264,
+      "title": "Requested talk: How on earth do you manage forms with Turbo?",
+      "description": "Turbo is an amazing tool that usually stays out of the way. Forms, however, come with some weird and wonderful quirks that can drive you insane.\n\nI'd love to hear a talk that covers things like:\n\n- Handling errors\n  - Status codes\n  - Double rendering\n- Redirecting after a form submission (esp when used inside a Turbo Frame)\n- Disabling Turbo on a form\n- Leveraging Turbo Streams\n- Inline validations and dynamic error messaging\n- Testing Turbo interactions",
+      "state": "closed",
+      "created_at": "2025-03-26T21:41:11Z",
+      "updated_at": "2025-06-15T23:49:22Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/264",
+      "comments": [
+        {
+          "id": 2837543140,
+          "user": "MattHood",
+          "body": "This is close to my heart, and I'm keen to do another RORO talk, so I'd love to pick this one up.\n\nIf anyone else is keen to get into this topic, feel free to get in touch - would be lovely to have a collaborator :)",
+          "created_at": "2025-04-29T05:55:32Z",
+          "updated_at": "2025-04-29T05:55:32Z"
+        },
+        {
+          "id": 2837698258,
+          "user": "HashNotAdam",
+          "body": "This would make me very happy, @MattHood 🫶",
+          "created_at": "2025-04-29T07:00:20Z",
+          "updated_at": "2025-04-29T07:00:20Z"
+        },
+        {
+          "id": 2974766765,
+          "user": "simran-sawhney",
+          "body": "Thanks @MattHood for the great showcase!",
+          "created_at": "2025-06-15T23:49:22Z",
+          "updated_at": "2025-06-15T23:49:22Z"
+        }
+      ]
+    },
+    {
+      "id": 2937083767,
+      "number": 261,
+      "title": "Talk Proposal: SQLite-ruby - a whole SQL database in a gem",
+      "description": "SQLite - the most deployed database that most people have never heard of - as a gem\n\nEstimated Talk Time: 5-20 minutes\n\nPrefered Month to Present: -\n\nPreferred Social media handles: @apocraphilia@hachyderm.io\n\n\n",
+      "state": "closed",
+      "created_at": "2025-03-21T02:27:14Z",
+      "updated_at": "2025-06-15T23:49:04Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/261",
+      "comments": [
+        {
+          "id": 2743086231,
+          "user": "HashNotAdam",
+          "body": "Can't believe I didn't think to add this as a requested talk. SQLite is so hot right now! Brilliant topic",
+          "created_at": "2025-03-21T11:26:12Z",
+          "updated_at": "2025-03-21T11:26:12Z"
+        },
+        {
+          "id": 2744948315,
+          "user": "simonhildebrandt",
+          "body": "When do you think we should do it?",
+          "created_at": "2025-03-22T03:33:11Z",
+          "updated_at": "2025-03-22T03:33:11Z"
+        },
+        {
+          "id": 2767587833,
+          "user": "simran-sawhney",
+          "body": "Hey @simonhildebrandt we can do this May if you like ? ",
+          "created_at": "2025-03-31T22:43:57Z",
+          "updated_at": "2025-03-31T22:43:57Z"
+        },
+        {
+          "id": 2767635531,
+          "user": "simonhildebrandt",
+          "body": "Sure - I'm in no rush if we wanna give other people a go, though. 😁 ",
+          "created_at": "2025-03-31T23:20:58Z",
+          "updated_at": "2025-03-31T23:20:58Z"
+        },
+        {
+          "id": 2887092647,
+          "user": "dkam",
+          "body": "I’m happy to do this for May, if Simon’s ok with that? I’d be aiming for a regular length talk rather than a lightning talk though. ",
+          "created_at": "2025-05-16T15:46:07Z",
+          "updated_at": "2025-05-16T15:46:07Z"
+        },
+        {
+          "id": 2887945296,
+          "user": "simonhildebrandt",
+          "body": "That'd be awesome, @dkam !\n",
+          "created_at": "2025-05-17T01:41:45Z",
+          "updated_at": "2025-05-17T01:41:45Z"
+        },
+        {
+          "id": 2892741817,
+          "user": "simran-sawhney",
+          "body": "Hey @dkam, are you planning to go for this one this month? \nSince we don’t have much lined up, I guess we could go for a proper talk instead lightning talk!\n\n",
+          "created_at": "2025-05-20T02:41:04Z",
+          "updated_at": "2025-05-20T02:41:04Z"
+        },
+        {
+          "id": 2974766570,
+          "user": "simran-sawhney",
+          "body": "Thanks @dkam for the amazing talk :) ",
+          "created_at": "2025-06-15T23:49:04Z",
+          "updated_at": "2025-06-15T23:49:04Z"
+        }
+      ]
+    }
+  ],
+  "March 2025": [
+    {
+      "id": 2944675321,
+      "number": 263,
+      "title": "Talk Proposal: Panel/Discussion/Riffing Session on Objects to encapsulate business logic",
+      "description": "Description(this will appear on youtube):\nA discussion about where to put business logic that may not belong in a traditional Rails Model. \n\nEstimated Talk Time:\n50 min\n\nPrefered Month to Present:\nMarch 2025\n\nPreferred Social media handles:\n@pinzonjulian @HashNotAdam \n",
+      "state": "closed",
+      "created_at": "2025-03-24T23:08:27Z",
+      "updated_at": "2025-03-31T00:41:04Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/263",
+      "comments": [
+        {
+          "id": 2764846933,
+          "user": "simran-sawhney",
+          "body": "Thanks @pinzonjulian and @HashNotAdam - it was so cool and great idea to engage the audience :) ",
+          "created_at": "2025-03-31T00:41:03Z",
+          "updated_at": "2025-03-31T00:41:03Z"
+        }
+      ]
+    },
+    {
+      "id": 2941730105,
+      "number": 262,
+      "title": "Talk Proposal: Rack Fundamentals revisited",
+      "description": "Description(this will appear on youtube): Learn the machinery that underpins our favourite frameworks, and why you might not need a whole Rails stack for an API that's basically a single method.\n\nEstimated Talk Time: 20 minutes\n\nPreferred Month to Present: March 2025\n\nPreferred Social media handles: @apocraphilia@hachyderm.io\n\nMugshot (will be use in the slides):\n\n![Image](https://github.com/user-attachments/assets/cc2b687a-6983-4093-8090-50112f772c87)\n",
+      "state": "closed",
+      "created_at": "2025-03-24T01:29:26Z",
+      "updated_at": "2025-03-31T00:40:12Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/262",
+      "comments": [
+        {
+          "id": 2764846205,
+          "user": "simran-sawhney",
+          "body": "Thanks @simonhildebrandt - it was really insightful",
+          "created_at": "2025-03-31T00:40:11Z",
+          "updated_at": "2025-03-31T00:40:11Z"
+        }
+      ]
+    }
+  ],
+  "February 2025": [
+    {
+      "id": 2855880198,
+      "number": 248,
+      "title": "Talk Proposal: Semantic Search and RAG with Ruby",
+      "description": "Description: From Embeddings to RAG: Building a Smart Search System in Ruby\n\nEstimated Talk Time: 20 minutes\n\nPrefered Month to Present: Feb\n\nPreferred Social media handles: @dkam on [GitHub](https://github.com/dkam/) and [Ruby Social](https://ruby.social/@dkam)\n\nMugshot (will be use in the slides):\n\n![Image](https://github.com/user-attachments/assets/6efe8b1d-3019-4c0d-b473-38aab5f50165)\n\n\n",
+      "state": "closed",
+      "created_at": "2025-02-16T04:49:47Z",
+      "updated_at": "2025-03-24T22:24:02Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/248",
+      "comments": [
+        {
+          "id": 2661271635,
+          "user": "HashNotAdam",
+          "body": "Thanks, @dkam, I'm looking forward to it",
+          "created_at": "2025-02-16T06:16:40Z",
+          "updated_at": "2025-02-16T06:16:40Z"
+        }
+      ]
+    }
+  ],
+  "January 2025": [
+    {
+      "id": 2808179722,
+      "number": 247,
+      "title": "Talk Proposal: The Inner Workings of Puma",
+      "description": "Description(this will appear on youtube): Most Rubyists use the Puma web server to handle requests, especially in their Rails applications. But how many of us truly understand its design, inner workings, and the powerful features it offers? In this session, we’ll dive into Puma’s internals, exploring its architecture and configuration options.\n\nEstimated Talk Time: 30-40 minutes\n\nPrefered Month to Present: January\n\nPreferred Social media handles:\n- https://bsky.app/profile/joshuay03.bsky.social\n- https://ruby.social/@joshuay03\n\nMugshot (will be use in the slides):\n![Image](https://github.com/user-attachments/assets/cad2ea3c-23f1-4c93-9222-b3e42a952b32)",
+      "state": "closed",
+      "created_at": "2025-01-23T23:53:04Z",
+      "updated_at": "2025-03-24T22:24:01Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/247",
+      "comments": []
+    },
+    {
+      "id": 2808082071,
+      "number": 246,
+      "title": "Talk Proposal: Ruby salad. What's fresh on the market?",
+      "description": "Description(this will appear on youtube): A review of some of new features in ruby 3.4 and rails 8. Including rails authentication generators and rodauth comparison.\n\nEstimated Talk Time: 40min\n\nPrefered Month to Present: January\n\nPreferred Social media handles: antulik on ruby slack\n\nMugshot (will be use in the slides): \n\n![Image](https://github.com/user-attachments/assets/ed08caaa-b142-4687-a3f5-43c1ca040bf6)\n",
+      "state": "closed",
+      "created_at": "2025-01-23T22:39:26Z",
+      "updated_at": "2025-03-24T22:24:01Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/246",
+      "comments": []
+    }
+  ],
+  "October 2024": [
+    {
+      "id": 2550597828,
+      "number": 245,
+      "title": "Talk Proposal:  'Cursor v Github Copilot: building a better data schema tool?'",
+      "description": "Description:\r\nAn evaluation of [Cursor](https://www.cursor.com/), how to configure it, which AI model to use, and a look at the pros and cons of [Cursor](https://www.cursor.com/) compared to GitHub Copilot.\r\n\r\nEstimated Talk Time:\r\n10–15 minutes\r\n\r\nPrefered Month to Present: October\r\n\r\nPreferred Social media handles: @ceels\r\n\r\nMugshot (will be use in the slides): lemme find one real quick\r\n![image](https://github.com/user-attachments/assets/e44e1475-2a29-48a3-ab50-636d63f06f63)\r\n\r\n",
+      "state": "closed",
+      "created_at": "2024-09-26T13:28:47Z",
+      "updated_at": "2024-10-28T00:31:35Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/245",
+      "comments": [
+        {
+          "id": 2381262487,
+          "user": "HashNotAdam",
+          "body": "Thanks, @ceels, I can't wait to watch",
+          "created_at": "2024-09-29T08:32:51Z",
+          "updated_at": "2024-09-29T08:32:51Z"
+        },
+        {
+          "id": 2395729064,
+          "user": "simran-sawhney",
+          "body": "Locking this for October @ceels - see you on 24th :) ",
+          "created_at": "2024-10-07T01:40:44Z",
+          "updated_at": "2024-10-07T01:40:44Z"
+        }
+      ]
+    },
+    {
+      "id": 2455100965,
+      "number": 239,
+      "title": "Talk Proposal: Happy Ruby SAML Development",
+      "description": "**Description (this will appear on YouTube):**\r\n\r\nThis talk is an introduction to how SAML requests and responses can be handled with Ruby, as well as a discussion around how we at [Covidence](https://www.covidence.org) have solved such challenges as:\r\n\r\n* Building SAML support ourselves rather than using third-party services.\r\n* Writing full feature tests to sign in via SSO (no mocking of SAML objects/responses).\r\n* Bridging SAML requests across many domains for staging/PR apps, to ensure a consistent approach across environments.\r\n* Parsing SAML metadata files using Nokogiri for better performance.\r\n\r\n**Estimated Talk Time:**\r\n\r\n20-30 minutes\r\n\r\n**Preferred Month to Present:**\r\n\r\nOctober or November 2024 (I'm away prior to that, sorry!)\r\n\r\n**Preferred Social media handles:**\r\n\r\nhttps://hachyderm.io/@pat\r\n\r\n**Mugshot (will be use in the slides):**\r\n\r\n![](https://media.hachyderm.io/accounts/avatars/109/308/312/683/593/994/original/49c39d379fbc3d37.jpg)\r\n[https://media.hachyderm.io/accounts/avatars/109/308/312/683/593/994/original/49c39d379fbc3d37.jpg](https://media.hachyderm.io/accounts/avatars/109/308/312/683/593/994/original/49c39d379fbc3d37.jpg)",
+      "state": "closed",
+      "created_at": "2024-08-08T07:39:40Z",
+      "updated_at": "2024-10-28T00:32:57Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/239",
+      "comments": [
+        {
+          "id": 2387787849,
+          "user": "simran-sawhney",
+          "body": "Hey @pat do you wanna go for it this month on 24th Oct ?",
+          "created_at": "2024-10-02T07:18:50Z",
+          "updated_at": "2024-10-02T07:18:50Z"
+        },
+        {
+          "id": 2387946314,
+          "user": "pat",
+          "body": "@simran-sawhney yup, let's lock it in 😁",
+          "created_at": "2024-10-02T08:47:58Z",
+          "updated_at": "2024-10-02T08:47:58Z"
+        }
+      ]
+    }
+  ],
+  "November 2024": [
+    {
+      "id": 2549232104,
+      "number": 244,
+      "title": "Talk Proposal: Turbo (Hotwire), Stimulusjs and being happy with front end development again",
+      "description": "Description(this will appear on youtube):\r\n\r\nI've done a lot of front end development work in my career. Think React, AngularJS, Rails UJS and JQuery enhanced pages. At no point can I say that I've enjoyed any of them, I was giving serious consideration to re-branding away from a full stack dev.\r\n\r\nEnter Hotwire and I'm actually enjoying it.\r\n\r\nThis is a peak into what life is like building and maintaining a modern Rails webapp.\r\n\r\nEstimated Talk Time:  15 - 20 mins?  I'll try and keep it short\r\n\r\nPreferred Month to Present: November 2024. I may have something for the October 24th meetup but I'll also only just be back from holidays...\r\n\r\nPreferred Social media handles: Twitter @gardengnome_au (in case anyone is still there...)\r\n\r\nMugshot (will be use in the slides):\r\n![image](https://github.com/user-attachments/assets/0d2f7fe2-829f-4781-93b6-2cf0ac9017e4)\r\n\r\n",
+      "state": "closed",
+      "created_at": "2024-09-26T00:36:39Z",
+      "updated_at": "2025-01-14T22:32:11Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/244",
+      "comments": [
+        {
+          "id": 2440259826,
+          "user": "simran-sawhney",
+          "body": "Hey @jeropaul - do you wanna do this on 28th November? ",
+          "created_at": "2024-10-28T00:32:29Z",
+          "updated_at": "2024-10-28T00:32:29Z"
+        },
+        {
+          "id": 2441328461,
+          "user": "friendlyantz",
+          "body": "keen! also interested in your take on HTMX",
+          "created_at": "2024-10-28T11:30:53Z",
+          "updated_at": "2024-10-28T11:31:09Z"
+        },
+        {
+          "id": 2443002633,
+          "user": "jeropaul",
+          "body": "@simran-sawhney yes I'll do this on the 28th of November",
+          "created_at": "2024-10-29T01:54:40Z",
+          "updated_at": "2024-10-29T01:54:40Z"
+        },
+        {
+          "id": 2492535482,
+          "user": "simran-sawhney",
+          "body": "hey @jeropaul - I was trying to find you over ruby Slack, couldnt come across your profile.\r\nSee you on 28th at BOYD library.",
+          "created_at": "2024-11-21T23:06:40Z",
+          "updated_at": "2024-11-21T23:06:40Z"
+        },
+        {
+          "id": 2492984153,
+          "user": "jeropaul",
+          "body": "Absolutely talk is ready! See you then.  (I'll also join slack)\r\n\r\nOn Fri, Nov 22, 2024, 10:07 Simran Sawhney ***@***.***> wrote:\r\n\r\n> hey @jeropaul <https://github.com/jeropaul> - I was trying to find you\r\n> over ruby Slack, couldnt come across your profile.\r\n> See you on 28th at BOYD library.\r\n>\r\n> —\r\n> Reply to this email directly, view it on GitHub\r\n> <https://github.com/rubyaustralia/melbourne-ruby/issues/244#issuecomment-2492535482>,\r\n> or unsubscribe\r\n> <https://github.com/notifications/unsubscribe-auth/AAD7GGPCO5JAW7AXQYHFPVL2BZRRLAVCNFSM6AAAAABO3YX2QWVHI2DSMVQWIX3LMV43OSLTON2WKQ3PNVWWK3TUHMZDIOJSGUZTKNBYGI>\r\n> .\r\n> You are receiving this because you were mentioned.Message ID:\r\n> ***@***.***>\r\n>\r\n",
+          "created_at": "2024-11-22T06:46:54Z",
+          "updated_at": "2024-11-22T06:46:54Z"
+        }
+      ]
+    },
+    {
+      "id": 2537782432,
+      "number": 242,
+      "title": "Requested Talk: How do `CurrentAttributes` work?",
+      "description": "**Description:**\r\nRails includes a class called `ActiveSupport::CurrentAttributes` that can be used to store values that relate only to the current request or job.\r\n\r\nFor example:\r\n```ruby\r\nclass Current < ActiveSupport::CurrentAttributes\r\n  attribute :user\r\nend\r\n\r\nCurrent.user = User.first\r\n```\r\n\r\nHow does Rails store these values?\r\nHow can it ensure these values can only be read in the current request?\r\nWhat happens when you change the isolation level?\r\nFrom a practical standpoint, what does the isolation level mean?\r\n\r\n**Estimated Talk Time:**\r\n10–15 minutes",
+      "state": "closed",
+      "created_at": "2024-09-20T03:46:00Z",
+      "updated_at": "2025-01-14T23:46:18Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/242",
+      "comments": [
+        {
+          "id": 2376616966,
+          "user": "darkfishy",
+          "body": "@HashNotAdam and @simran-sawhney\nI could talk about this in November, with proper presentation slides then 😅",
+          "created_at": "2024-09-26T10:55:57Z",
+          "updated_at": "2024-09-26T10:55:57Z"
+        }
+      ]
+    }
+  ],
+  "September 2024": [
+    {
+      "id": 2537778854,
+      "number": 241,
+      "title": "Requested Talk: How does `reload!` work?",
+      "description": "**Description:**\r\nWhen using the Rails console, you can call `reload!` to reset the environment.\r\nHow does this work?\r\nHow does it know which classes to reload?\r\nHow does a class get reloaded?\r\nWhat are the implications for intializers?\r\n\r\n**Estimated Talk Time:**\r\n10–15 minutes",
+      "state": "closed",
+      "created_at": "2024-09-20T03:41:46Z",
+      "updated_at": "2024-10-02T07:20:46Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/241",
+      "comments": [
+        {
+          "id": 2367337228,
+          "user": "darkfishy",
+          "body": "@HashNotAdam and @simran-sawhney I can present on this topic at the next meeting.",
+          "created_at": "2024-09-23T06:36:18Z",
+          "updated_at": "2024-09-23T06:36:18Z"
+        },
+        {
+          "id": 2372747968,
+          "user": "HashNotAdam",
+          "body": "Thanks so much, @darkfishy, that's a big help. Would you might filling out the following?\r\n\r\nDescription(this will appear on youtube):\r\n\r\nPreferred Social media handles:\r\n\r\nMugshot (will be use in the slides):\r\n",
+          "created_at": "2024-09-25T02:14:44Z",
+          "updated_at": "2024-09-25T02:14:44Z"
+        },
+        {
+          "id": 2373063637,
+          "user": "darkfishy",
+          "body": "Hey @HashNotAdam \r\n\r\n> Description(this will appear on youtube):\r\n\r\nSame as above in https://github.com/rubyaustralia/melbourne-ruby/issues/241#issue-2537778854\r\n\r\n> Preferred Social media handles:\r\n\r\nhttps://x.com/fusionfish\r\n\r\n> Mugshot (will be use in the slides):\r\n\r\nSupplied to @simran-sawhney \r\n",
+          "created_at": "2024-09-25T05:35:29Z",
+          "updated_at": "2024-09-25T05:35:29Z"
+        },
+        {
+          "id": 2387790827,
+          "user": "simran-sawhney",
+          "body": "Thanks @darkfishy for putting it all together :) ",
+          "created_at": "2024-10-02T07:20:46Z",
+          "updated_at": "2024-10-02T07:20:46Z"
+        }
+      ]
+    },
+    {
+      "id": 2520782749,
+      "number": 240,
+      "title": "Talk Proposal: Oaken - A fresh take on seeds and fixtures",
+      "description": "Description(this will appear on youtube): Exploring Oaken - A fresh take on seeds and fixtures\n\nEstimated Talk Time: 30min\n\nPrefered Month to Present: September \n\nPreferred Social media handles: pinzonjulian everywhere\n\nMugshot (will be use in the slides): TBD",
+      "state": "closed",
+      "created_at": "2024-09-11T21:10:00Z",
+      "updated_at": "2024-10-02T07:21:06Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/240",
+      "comments": [
+        {
+          "id": 2344711152,
+          "user": "pinzonjulian",
+          "body": "This addresses two past issues I posed a while ago for talks I wanted to see!\n#159\n#168",
+          "created_at": "2024-09-11T21:12:07Z",
+          "updated_at": "2024-09-11T21:13:18Z"
+        },
+        {
+          "id": 2345009702,
+          "user": "HashNotAdam",
+          "body": "You have my attention with that title 😃 ",
+          "created_at": "2024-09-12T00:14:40Z",
+          "updated_at": "2024-09-12T00:14:40Z"
+        },
+        {
+          "id": 2373647707,
+          "user": "HashNotAdam",
+          "body": "@pinzonjulian I've used the photo from GitHub, but you're welcome to supply another",
+          "created_at": "2024-09-25T10:09:57Z",
+          "updated_at": "2024-09-25T10:09:57Z"
+        },
+        {
+          "id": 2387791305,
+          "user": "simran-sawhney",
+          "body": "Thanks @pinzonjulian, it was a great talk!",
+          "created_at": "2024-10-02T07:21:05Z",
+          "updated_at": "2024-10-02T07:21:05Z"
+        }
+      ]
+    }
+  ],
+  "August 2024": [
+    {
+      "id": 2446778748,
+      "number": 238,
+      "title": "Talk Proposal: My Career Change - Nothing is what it seems",
+      "description": "Description(this will appear on youtube):\r\nMy career change story: why am I here? How did I get here? This is the talk I gave at the Rails Girls Workshop to hopefully inspire others to make the change, or at the very least provide some entertaining and relatable anecdotes.\r\n\r\nEstimated Talk Time: 10 mins\r\n\r\nPreferred Month to Present: August 2024\r\n\r\nPreferred Social media handles: Twitter @cinnamonbabies, https://www.linkedin.com/in/helen-stonehouse/\r\n\r\nMugshot (will be use in the slides): \r\n![bratbg](https://github.com/user-attachments/assets/5edba73e-f5cc-463d-992c-144359eaddbb)\r\n\r\n",
+      "state": "closed",
+      "created_at": "2024-08-04T03:50:35Z",
+      "updated_at": "2024-09-05T03:14:31Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/238",
+      "comments": []
+    },
+    {
+      "id": 2437892166,
+      "number": 237,
+      "title": "Talk Proposal: Rails Engines in 20 minutes",
+      "description": "Description(this will appear on youtube):\r\nIn this talk, we'll walk through building a basic Rails plugin and talk about the different ways of extending Rails through Engines.\r\n\r\nEstimated Talk Time: \r\n20mins\r\n\r\nPrefered Month to Present: \r\nAugust\r\n\r\nPreferred Social media handles: \r\n@excid3\r\n\r\nMugshot (will be use in the slides):\r\nhttps://rubyonrails.org/assets/world/2023/images/speakers/c-oliver.jpg",
+      "state": "closed",
+      "created_at": "2024-07-30T13:48:54Z",
+      "updated_at": "2024-09-05T03:14:48Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/237",
+      "comments": [
+        {
+          "id": 2259569119,
+          "user": "simran-sawhney",
+          "body": "Thanks @excid3 - community would be so proud and excited to hear it from you !!!🔥",
+          "created_at": "2024-07-31T03:29:15Z",
+          "updated_at": "2024-07-31T03:29:15Z"
+        }
+      ]
+    }
+  ],
+  "July 2024": [
+    {
+      "id": 2363828597,
+      "number": 235,
+      "title": "Talk Proposal: Pinkest Pink",
+      "description": "Description:\r\nDid you know the web got new colors? The pink is pinker than it used to be. The colors are so bright and we can use them on web pages. I'm not an expert in this space but I am excited to share what I've learned about the topic, like how our eyes work and how we try to recreate reality on a screen.\r\n\r\nEstimated Talk Time: 10 or 20min, can probably scope it to a lightning talk if it's better for timing\r\n\r\nPrefered Month to Present: No preference, can do with short notice if needed\r\n\r\nPreferred Social media handles: `@danlaush`, https://danlaush.biz/\r\n\r\nMugshot (will be use in the slides):\r\nhttps://github.com/rubyaustralia/melbourne-ruby/assets/1204500/da13da31-84bb-4e52-baa5-372a7f304195\r\n\r\n",
+      "state": "closed",
+      "created_at": "2024-06-20T08:18:46Z",
+      "updated_at": "2024-07-26T06:40:46Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/235",
+      "comments": [
+        {
+          "id": 2201970934,
+          "user": "simran-sawhney",
+          "body": "hey @danlaush - do you wanna do this for this month at 25th July?",
+          "created_at": "2024-07-02T05:32:45Z",
+          "updated_at": "2024-07-02T05:32:45Z"
+        },
+        {
+          "id": 2208162699,
+          "user": "danlaush",
+          "body": "Hey Simran, sure I'd be happy to. It's pretty solid with a 15min run time, does that work?",
+          "created_at": "2024-07-04T05:47:04Z",
+          "updated_at": "2024-07-04T05:47:04Z"
+        },
+        {
+          "id": 2224213298,
+          "user": "simran-sawhney",
+          "body": "Hey @danlaush yep that will work fine. Let's do it mate on 25th July (Thursday)\r\nHere is the event details. https://www.meetup.com/ruby-on-rails-oceania-melbourne/events/297781282/",
+          "created_at": "2024-07-12T00:35:50Z",
+          "updated_at": "2024-07-12T00:35:50Z"
+        },
+        {
+          "id": 2229761689,
+          "user": "simran-sawhney",
+          "body": "Hey @danlaush - could you please confirm it so I can lock it in for the event?\r\nThanks mate,",
+          "created_at": "2024-07-16T00:50:07Z",
+          "updated_at": "2024-07-16T00:50:07Z"
+        },
+        {
+          "id": 2230088500,
+          "user": "danlaush",
+          "body": "Oh whoops I didn't submit what I wrote earlier! Yes I'm in, thanks for accepting and looking forward to it.",
+          "created_at": "2024-07-16T06:01:24Z",
+          "updated_at": "2024-07-16T06:01:24Z"
+        },
+        {
+          "id": 2249527403,
+          "user": "danlaush",
+          "body": "@simran-sawhney do you need a PDF/document for the talk or will I be able to plug my laptop in?",
+          "created_at": "2024-07-25T06:03:46Z",
+          "updated_at": "2024-07-25T06:03:46Z"
+        },
+        {
+          "id": 2252078156,
+          "user": "simran-sawhney",
+          "body": "Sorry I just saw your comment now, thanks for the amazing talk last night!",
+          "created_at": "2024-07-26T06:40:46Z",
+          "updated_at": "2024-07-26T06:40:46Z"
+        }
+      ]
+    },
+    {
+      "id": 2301498429,
+      "number": 233,
+      "title": "Talk Proposal: Being a Good Male Ally",
+      "description": "Description(this will appear on youtube):\r\nBeing a Good Male Ally\r\n\r\nEstimated Talk Time:\r\n15-20 minutes. \r\nPrefered Month to Present:\r\nMay\r\nPreferred Social media handles:\r\nhttps://nickwolf.com.au",
+      "state": "closed",
+      "created_at": "2024-05-16T22:38:58Z",
+      "updated_at": "2024-07-26T06:40:09Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/233",
+      "comments": [
+        {
+          "id": 2201972054,
+          "user": "simran-sawhney",
+          "body": "hey @quintrino - do you wanna do this on 25th July - Thursday?",
+          "created_at": "2024-07-02T05:33:50Z",
+          "updated_at": "2024-07-02T05:33:50Z"
+        },
+        {
+          "id": 2204704008,
+          "user": "quintrino",
+          "body": "Sounds good to me. ",
+          "created_at": "2024-07-02T23:43:58Z",
+          "updated_at": "2024-07-02T23:43:58Z"
+        },
+        {
+          "id": 2252077469,
+          "user": "simran-sawhney",
+          "body": "Thanks for the amazing talk!",
+          "created_at": "2024-07-26T06:40:09Z",
+          "updated_at": "2024-07-26T06:40:09Z"
+        }
+      ]
+    }
+  ],
+  "June 2024": [
+    {
+      "id": 2271079974,
+      "number": 232,
+      "title": "Talk Proposal: One does not simply... rebuild a product",
+      "description": "Description(this will appear on youtube): \r\n\r\n\"A rebuild is never finished, only started\"\r\n\r\nWe're rebuilding Culture Amp's second largest product - Performance. It's 9 years old, came in as a Series A acquisition 5 years ago, has over 2700 customers with the largest one at 77k users. Against conventional wisdom, we're rebuilding it from the ground up with an aggressive timeline. The underlying model is outdated, slow to iterate on, and not extensible. The monoliths are riddled with tech debt, tightly coupled, patched and band-aided over many times, and won't scale to the $3b global Performance market we're targeting.\r\n\r\nThat wasn't challenging enough already so I'm also using this opportunity to rebuild our engineering culture. Setting a high bar for engineering standards, ways of working, and hoping to improve engagement as we go.\r\n\r\nIn this talk, I'll share:\r\n\r\n- How I came to this decision\r\n- How we got buy in from Exec and the Board for a purely technical rebuild\r\n- How we tried to set up for success, our principles and standards\r\n- Where we failed\r\n- Where we succeeded\r\n- Lessons that could be useful for anyone thinking about rebuilding a product that's hampering speed and hindering your ability to innovate or deliver value to your customers.\r\n\r\nThe rebuild is still in progress. I don't have all the answers (or any!). But we've already learned much - what to do, what not to do, and where the spiders are hiding.\r\n\r\nEstimated Talk Time: 35 - 40 minutes\r\n\r\nPreferred Month to Present: June\r\n\r\nPreferred Social media handles: https://www.linkedin.com/in/prakritimateti/\r\n\r\nMugshot (will be use in the slides): [link to photo](https://github.com/rubyaustralia/melbourne-ruby/assets/502956/6fd7dfe4-5f49-4c48-bccd-8784e41e48b7)\r\n\r\n\r\n",
+      "state": "closed",
+      "created_at": "2024-04-30T10:20:29Z",
+      "updated_at": "2024-07-02T05:31:46Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/232",
+      "comments": [
+        {
+          "id": 2151362698,
+          "user": "simran-sawhney",
+          "body": "Thanks @itirkarp - let's do it this month on 27th June ",
+          "created_at": "2024-06-06T03:54:57Z",
+          "updated_at": "2024-06-06T03:54:57Z"
+        }
+      ]
+    },
+    {
+      "id": 2254940264,
+      "number": 231,
+      "title": "Laravel, meet my friend Turbo",
+      "description": "I've been playing around with the PHP framework, Laravel, and looking at how to use it with Turbo, Turbo Native, and Strada.\r\n\r\nI will be giving a full talk for the PHP community that includes explanations of Turbo, Turbo Native, and Strada, as well as a comparison between Turbo and Livewire.\r\n\r\nIt would be simple enough for me to modify the talk to fit a Ruby audience, and I could set the length based on the other talks that will be given on that day. For example, if this were a full talk, I could discuss what Laravel is, the similarities to Rails, and dig a bit into the line between Turbo Native and Strada. If it were to be a lightning talk, we could skip most of the background and just do a walkthrough.",
+      "state": "closed",
+      "created_at": "2024-04-21T07:17:29Z",
+      "updated_at": "2024-07-02T05:31:57Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/231",
+      "comments": []
+    }
+  ],
+  "May 2024": [
+    {
+      "id": 2251647844,
+      "number": 230,
+      "title": "Cursors: Why Pagination is Bad-gination!",
+      "description": "Using Ruby to explain a popular new approach to accessing and displaying data, without the staleness issues of traditional pagination - cursors! Learn the basic concepts, and find out why this approach is popular in modern toolkits like GraphQL.\r\n\r\nProbably 20 to 30 minutes.",
+      "state": "closed",
+      "created_at": "2024-04-18T21:59:14Z",
+      "updated_at": "2024-06-06T03:55:35Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/230",
+      "comments": []
+    }
+  ],
+  "April 2024": [
+    {
+      "id": 2245115139,
+      "number": 229,
+      "title": "Dissecting Rails",
+      "description": "Lightning talk for RORO Melbourne\r\n\r\n__Title:__ Dissecting Rails \r\n__About:__ How I learn Rails. My takeaways from dissecting Rails: Active Support, Active Model, etc\r\n\r\n__Timing:__ APR-2024\r\n\r\n>    Are you happy to have your talk published on the RubyAU YouTube channel? -> yes\r\n    Your Twitter username (if you have one) -> [@friendlyantz](https://twitter.com/friendlyantz)\r\n    Link to, or upload of, a photo of yourself that will appear in the meetup slide deck: refer https://github.com/rubyaustralia/melbourne-ruby/issues/192\r\n\r\nLength: 10-15min",
+      "state": "closed",
+      "created_at": "2024-04-16T05:21:27Z",
+      "updated_at": "2024-04-29T02:06:37Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/229",
+      "comments": [
+        {
+          "id": 2081778776,
+          "user": "simran-sawhney",
+          "body": "Thanks @friendlyantz for your insightful talk :) ",
+          "created_at": "2024-04-29T02:06:37Z",
+          "updated_at": "2024-04-29T02:06:37Z"
+        }
+      ]
+    }
+  ],
+  "March 2024": [
+    {
+      "id": 2166041203,
+      "number": 228,
+      "title": "One Billion Rows in Ruby",
+      "description": "Description(this will appear on youtube):\r\nIs Ruby a good language for CPU-intensive data crunching? Can it beat Java? This talk is about my adventures taking on the One Billion Row Challenge (https://github.com/gunnarmorling/1brc) in Ruby. I'll cover some of the tools, techniques and pitfalls around optimising Ruby programs.\r\n\r\nEstimated Talk Time: maybe 30 minutes? (haven't timed it yet)\r\n\r\nPreferred Month to Present: March 2024\r\n\r\nPreferred Social media handles: None\r\n\r\nMugshot (will be use in the slides): https://avatars.githubusercontent.com/u/1201065",
+      "state": "closed",
+      "created_at": "2024-03-04T06:27:53Z",
+      "updated_at": "2024-04-03T23:19:10Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/228",
+      "comments": [
+        {
+          "id": 1992941578,
+          "user": "simran-sawhney",
+          "body": "Thanks @rianmcguire - let's do it on 28th March!",
+          "created_at": "2024-03-13T01:17:25Z",
+          "updated_at": "2024-03-13T01:17:25Z"
+        },
+        {
+          "id": 2035796150,
+          "user": "simran-sawhney",
+          "body": "Thanks @rianmcguire for your amazing talk!",
+          "created_at": "2024-04-03T23:19:09Z",
+          "updated_at": "2024-04-03T23:19:09Z"
+        }
+      ]
+    },
+    {
+      "id": 2165644521,
+      "number": 227,
+      "title": "The Economics of Ruby",
+      "description": "Description(this will appear on youtube):\r\nJohn is a developer that likes both Ruby and Economics.  \r\n\r\nThis is a lightning talk about the flow of resources and incentives in the Ruby ecosystem.  It will discuss the costs of maintaining Ruby, the support from various benefactors/companies, and the contributors that make it all happen.\r\n\r\nEstimated Talk Time: 10 minutes\r\n\r\nPrefered Month to Present: March 2024\r\n\r\nPreferred Social media handles: \r\nhttps://twitter.com/ponny\r\n\r\nMugshot (will be use in the slides): just use my github avatar\r\n",
+      "state": "closed",
+      "created_at": "2024-03-04T00:10:04Z",
+      "updated_at": "2024-04-29T02:06:22Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/227",
+      "comments": [
+        {
+          "id": 1992940900,
+          "user": "simran-sawhney",
+          "body": "Thanks @ponny - let's do this on 28th March! ",
+          "created_at": "2024-03-13T01:17:11Z",
+          "updated_at": "2024-03-13T01:17:11Z"
+        },
+        {
+          "id": 2035796354,
+          "user": "simran-sawhney",
+          "body": "Thanks @ponny for your amazing talk!",
+          "created_at": "2024-04-03T23:19:29Z",
+          "updated_at": "2024-04-03T23:19:29Z"
+        },
+        {
+          "id": 2038639122,
+          "user": "ponny",
+          "body": "@simran-sawhney No worries.  A couple of people asked for the vid so could you please post it here when it's up?",
+          "created_at": "2024-04-05T02:19:44Z",
+          "updated_at": "2024-04-05T02:19:44Z"
+        },
+        {
+          "id": 2081778615,
+          "user": "simran-sawhney",
+          "body": "@ponny here is the posted video link!\r\nhttps://www.youtube.com/watch?v=ydU3WvLoXpY\r\n",
+          "created_at": "2024-04-29T02:06:21Z",
+          "updated_at": "2024-04-29T02:06:21Z"
+        }
+      ]
+    }
+  ],
+  "Feb 2024": [
+    {
+      "id": 2126276849,
+      "number": 226,
+      "title": "Can I host a rails app from a home server?",
+      "description": "With the advent of cloud and the availability of PaaS (Platform as a Service) providers like Heroku, Fly.io, Render, and Hatchbox, why would even consider running a **rails app** on **bare metal** from home?\r\n- because you can?\r\n- because it's cheaper?\r\n- because you want to be your own sysadmin/devops?\r\n- because you want the internet to be back like it was in **1999 🎉 !!!**\r\n- because there has been some recent noise on this in the Rails community\r\n    **[RECLAIM THE STACK!](https://reclaim-the-stack.com/)**\r\n    > We spent 7 months building a Kubernetes based platform to replace Heroku. The results were a 90% reduction in costs and a 30% improvement in performance.\r\n    \r\n    **[KAMAL](https://kamal-deploy.org/)** _formerly MRSK_\r\n    > Leaving the cloud will save us $7 million over five years.\r\n    https://basecamp.com/cloud-exit\r\n- because @friendlyantz - wants to know\r\n    [Ruby Australia Slack #melb-meets 3:27pm Oct 5 2023](https://rubyau.slack.com/archives/C010RUGPRHU/p1696480053027199?thread_ts=1696479747.231869&cid=C010RUGPRHU)\r\n  > Keen to hear about these topics(hope it inspires someone):\r\n  >  * Self hosting ruby app\r\n\r\nSo **\"can I host a rails app from a home server?\"** whats involved? how hard can it be? is it just `RAILS_ENV=production bin/rails server`?\r\n\r\nlet's see how far I can get - maybe a **5 minute talk** or maybe **30 minutes** depending how far I get\r\n\r\nNOTE: _this is part of a larger talk idea for running a rails app locally on **bare metal** using a laptop, moving it into the **cloud☁️** and back again on-premise on **bare metal** home cluster_\r\n\r\n",
+      "state": "closed",
+      "created_at": "2024-02-09T00:28:00Z",
+      "updated_at": "2024-03-03T23:36:19Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/226",
+      "comments": [
+        {
+          "id": 1975398941,
+          "user": "simran-sawhney",
+          "body": "Thanks for the great talk @saramic ! ",
+          "created_at": "2024-03-03T23:36:18Z",
+          "updated_at": "2024-03-03T23:36:18Z"
+        }
+      ]
+    },
+    {
+      "id": 2112381409,
+      "number": 224,
+      "title": "Talk Proposal : System Design & Distributed System Lightweight Concept",
+      "description": "- What to do when our app gains popularity (Vertical & Horizontal Scaling)\r\n- Horizontal scaling best practices (instance stickiness, louse coupling ) \r\n-  Distributed Systems ( stuff like chaos monkeys, retry mechanism should be somewhat fun )\r\n- Could also talk abt some tools like kubernetes ( just the lightweight stuff like k8 backgrounds, pods, deleting pods , scalling , and a bit abt writing .yaml file not the advanced or super detailed ) . ",
+      "state": "closed",
+      "created_at": "2024-02-01T12:18:37Z",
+      "updated_at": "2024-03-03T23:36:35Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/224",
+      "comments": [
+        {
+          "id": 1933094663,
+          "user": "simran-sawhney",
+          "body": "hey @Stefanuswilfrid - . It's a great topic but for it to be qualified for lightning talk, this seems bit too heavy. Is there any chance if you could decrease the presentation and talk time to 10 minutes maximum and realign the details in your slides accordingly ?",
+          "created_at": "2024-02-07T23:19:17Z",
+          "updated_at": "2024-02-07T23:19:17Z"
+        },
+        {
+          "id": 1933243342,
+          "user": "ZimbiX",
+          "body": "Or have it be a full talk?",
+          "created_at": "2024-02-08T01:54:12Z",
+          "updated_at": "2024-02-08T01:54:12Z"
+        },
+        {
+          "id": 1933247140,
+          "user": "Stefanuswilfrid",
+          "body": "hey , ur right i think for the lightning talk i'l just talk abt 'scaling you app 101' . in the bginning i thought i was supposed to propose about topics for multiple weeks lol. ",
+          "created_at": "2024-02-08T01:59:34Z",
+          "updated_at": "2024-02-08T01:59:34Z"
+        },
+        {
+          "id": 1975399044,
+          "user": "simran-sawhney",
+          "body": "Thanks for the talk @Stefanuswilfrid ! ",
+          "created_at": "2024-03-03T23:36:34Z",
+          "updated_at": "2024-03-03T23:36:34Z"
+        }
+      ]
+    }
+  ],
+  "January 2024": [
+    {
+      "id": 2080633355,
+      "number": 223,
+      "title": "Processing DMARC reports via Action Mailbox",
+      "description": "Domain-based Message Authentication, Reporting, and Conformance (or DMARC) is an email validation system that builds upon Sender Policy Framework (SPF) and DomainKeys Identified Mail (DKIM) to protect email domains from being used in email spoofing, phishing scams, and other cybercrime.\r\n\r\nWhen creating a DMARC DNS record, you can include a `rua` attribute, the value of which is an email address that servers can send a daily report of the deliverability of emails from your domain. This provides valuable data that can help you check that you've approved every server that you expect to be able to send on your behalf and reduce the number of legitimate emails that are sent to spam. Unfortunately, these reports come as XML files which are usually GZipped which makes them poorly suited to human reading. Also, since they are sent by the receiving servers, you can expect to be sent many reports per day.\r\n\r\nThis talk is the story of how I leveraged Action Mailbox in Ruby on Rails to automatically parse incoming DMARC reports and alert me to issues in a human-readable format.",
+      "state": "closed",
+      "created_at": "2024-01-14T08:28:33Z",
+      "updated_at": "2024-01-29T02:15:22Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/223",
+      "comments": [
+        {
+          "id": 1913847853,
+          "user": "simran-sawhney",
+          "body": "Thanks for the great talk @HashNotAdam ",
+          "created_at": "2024-01-29T02:15:22Z",
+          "updated_at": "2024-01-29T02:15:22Z"
+        }
+      ]
+    },
+    {
+      "id": 2075457487,
+      "number": 222,
+      "title": "Something Something Fibers Something",
+      "description": "Yes, the title of the talk is \"Something Something Fibers Something\" - I'll try and nail down more specifically what I want to talk about this weekend :)\r\n\r\nI'd like to do a talk that really gets into the low-level guts of how fibers work in Ruby. The rough kind of thing I'm thinking of covering is...\r\n\r\n* What a Fiber is, and how fibers relate to threads\r\n* How Fiber.yield/Fiber.resume work in Ruby\r\n* What you can build with them (e.g. implementing enumerators with them, \"saving\" the context of being inside a block)\r\n* How the Ruby and C call stacks relate to each other (this is important prerequisite info which is kind of genuinely interesting on its own)\r\n* How Fiber.yield and Fiber.resume are implemented in terms of the C call stack\r\n\r\nI would also like to talk about Fiber.transfer & the new Ruby fiber scheduler interface & the async gem, but let's see how much content ☝️  turns out to be. Maybe it's a different talk for another time.\r\n\r\nI'll be able to present this on Jan 25.",
+      "state": "closed",
+      "created_at": "2024-01-11T00:23:43Z",
+      "updated_at": "2024-01-29T02:15:33Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/222",
+      "comments": [
+        {
+          "id": 1893315132,
+          "user": "ZimbiX",
+          "body": "Very cool. I've been keen for a talk like this since Ruby 3 came out :grin:",
+          "created_at": "2024-01-16T08:57:44Z",
+          "updated_at": "2024-01-16T08:57:44Z"
+        },
+        {
+          "id": 1913847986,
+          "user": "simran-sawhney",
+          "body": "Thanks for the great talk @KJTsanaktsidis ",
+          "created_at": "2024-01-29T02:15:33Z",
+          "updated_at": "2024-01-29T02:15:33Z"
+        }
+      ]
+    }
+  ],
+  "November 2023": [
+    {
+      "id": 2010461264,
+      "number": 221,
+      "title": "Proposal: precious gems I've learned during my first dev year (10-15min lightning talk)",
+      "description": "Title: Precious gems I've learned in my first dev year\r\nAbout: Not the ruby gems but more like gems of wisdom that I've experienced during my first developer year. Lots of self reflection to be done and just want to share some of them\r\n\r\nTiming: 29th Nov 2023\r\nLength: 10 - 15min Lightning talk",
+      "state": "closed",
+      "created_at": "2023-11-25T03:59:34Z",
+      "updated_at": "2023-12-06T03:46:10Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/221",
+      "comments": [
+        {
+          "id": 1826675822,
+          "user": "optimistic-updt",
+          "body": "hey Justin, \r\nAre you keen to do this in November?\r\n",
+          "created_at": "2023-11-26T06:56:50Z",
+          "updated_at": "2023-11-26T06:56:50Z"
+        },
+        {
+          "id": 1826727532,
+          "user": "j-tws",
+          "body": "Yeah can do! That will be this coming Wed right?",
+          "created_at": "2023-11-26T08:58:54Z",
+          "updated_at": "2023-11-26T08:58:54Z"
+        },
+        {
+          "id": 1826754456,
+          "user": "optimistic-updt",
+          "body": "yep",
+          "created_at": "2023-11-26T11:11:10Z",
+          "updated_at": "2023-11-26T11:11:10Z"
+        }
+      ]
+    },
+    {
+      "id": 1929166227,
+      "number": 218,
+      "title": "[discussion]: Rails architecture with engines work group",
+      "description": "I'll demo an app and talk about my experience for a little bit. The goal is to have an audience discussion and share experiences about using rails engines. Other people are welcome to demo their examples as well.\r\n\r\nLength: 1-1.5 hour discussion",
+      "state": "closed",
+      "created_at": "2023-10-05T22:27:52Z",
+      "updated_at": "2023-12-06T03:46:18Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/218",
+      "comments": [
+        {
+          "id": 1765944447,
+          "user": "optimistic-updt",
+          "body": "that sounds awesome,\r\nLet's maybe have it in november ❤️ \r\n",
+          "created_at": "2023-10-17T08:39:08Z",
+          "updated_at": "2023-10-17T08:39:08Z"
+        },
+        {
+          "id": 1826674249,
+          "user": "optimistic-updt",
+          "body": "are you stil happy to this next week?",
+          "created_at": "2023-11-26T06:56:13Z",
+          "updated_at": "2023-11-26T06:56:13Z"
+        },
+        {
+          "id": 1827053680,
+          "user": "antulik",
+          "body": "yes",
+          "created_at": "2023-11-27T03:04:02Z",
+          "updated_at": "2023-11-27T03:04:02Z"
+        }
+      ]
+    }
+  ],
+  "October 2023": [
+    {
+      "id": 1956158778,
+      "number": 220,
+      "title": "Proposal: Showcase of final project of my bootcamp with Academy Xi",
+      "description": "Description: A showcase of my full stack web app built for the final project of the bootcamp I have completed with Academy Xi. Made with Rails and React\r\n\r\nTalk time: 20mins \r\n\r\nMonth: October\r\n\r\nSocial Media: \r\nhttp://linkedin.com/in/thdev\r\n\r\nPortfolio \r\nThdev.com.au\r\n\r\n![IMG_1742](https://github.com/rubyaustralia/melbourne-ruby/assets/59306359/5ae6893b-4249-480a-942e-33bd88cba93b)\r\n",
+      "state": "closed",
+      "created_at": "2023-10-23T01:09:04Z",
+      "updated_at": "2023-11-26T06:15:48Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/220",
+      "comments": []
+    },
+    {
+      "id": 1956091676,
+      "number": 219,
+      "title": "Thoughts on Environment Variables",
+      "description": "A lightning talk 5 - 10 minutes on managing environment variables in rails.\r\n\r\n> You're app is coming along and all of a sudden you need to configure the number of workers, or an endpoint to access an API. You reach for `CONSTANTS` but very quickly you find out that these will vary between **development**, **test** and **production** apps. Not only that but you have a number of **\"production\"** apps like _staging_, _sandbox_, _UAT_ and the like. You also read up about [The Twelve-Factor App](https://12factor.net/) and you go for **Environment Variables** (`ENV_VARS`) to configure everything. But development becomes a night mare so you use `.env` files to store all these configurations. And then you get an API **Key 🔑** or **Secret 🔐** and you also through it into the `.env` file and even commit it to Git!!! 🚨 - at night you here yourself counselling yourself\r\n>    \"it's OK, it's a private repo\"\r\n>    \"it's OK, it's only a developer secret\"\r\n\r\nIt's **NOT OK** this is the kind of behaviour that leads to security breaches and people being fired! - let's not blame the individuals but the process. The process of not having an easy way to store and share secrets is the root of the problem, and not developers accidentally sharing secrets they haphazardly saved to their publicly visible `.Dotfiles` git hub repo\r\n\r\nLearn:\r\n1. why to use Env Vars\r\n2. how to use `.env` https://github.com/bkeepers/dotenv and why it's a bad idea\r\n3. how to use **rails credentials** as well as Shopify's EJson, or Mozillas SOPS or Ansible's Vault\r\n4. how to easily manage and override credentials using Evil Martians AnywayConfg\r\n5. and why you should never be complacent with the way things are - learn how to break your system to make a better system\r\n\r\nwith code examples - https://github.com/failure-driven/env-var-demo",
+      "state": "closed",
+      "created_at": "2023-10-22T23:04:19Z",
+      "updated_at": "2023-11-27T01:18:16Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/219",
+      "comments": [
+        {
+          "id": 1774376100,
+          "user": "ponny",
+          "body": "Keen for this.",
+          "created_at": "2023-10-23T03:31:26Z",
+          "updated_at": "2023-10-23T03:31:26Z"
+        },
+        {
+          "id": 1826987104,
+          "user": "saramic",
+          "body": "@ponny - not sure I did the topic justice but in case you were interested -> https://www.youtube.com/watch?v=Pf-IrWRm-UE",
+          "created_at": "2023-11-27T01:18:16Z",
+          "updated_at": "2023-11-27T01:18:16Z"
+        }
+      ]
+    }
+  ],
+  "September 2023": [
+    {
+      "id": 1870695080,
+      "number": 217,
+      "title": "Talk proposal: Rails forms",
+      "description": "I can do a lighting talk about rails forms and service objects",
+      "state": "closed",
+      "created_at": "2023-08-29T00:37:30Z",
+      "updated_at": "2023-10-01T23:05:26Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/217",
+      "comments": [
+        {
+          "id": 1698246150,
+          "user": "friendlyantz",
+          "body": "yes please!",
+          "created_at": "2023-08-29T22:51:52Z",
+          "updated_at": "2023-08-29T22:51:52Z"
+        },
+        {
+          "id": 1713259150,
+          "user": "simran-sawhney",
+          "body": "Alright let's do mate this month @antulik",
+          "created_at": "2023-09-11T06:40:20Z",
+          "updated_at": "2023-09-11T06:40:20Z"
+        },
+        {
+          "id": 1714840378,
+          "user": "antulik",
+          "body": "it's a lightning talk, so 5min, but will probably stretch to 10min.",
+          "created_at": "2023-09-12T01:43:50Z",
+          "updated_at": "2023-09-12T01:43:50Z"
+        }
+      ]
+    },
+    {
+      "id": 1784427256,
+      "number": 210,
+      "title": "Unleashing the Power of Pair Presenting: Elevate Your Conference Impact",
+      "description": "I was commissioned to write this talk for an international group, put in a lot of effort, heard the content was great, and would like to share it with all of you!\r\n\r\n\r\nDescription:\r\nDiscover the transformative potential of pair presenting at conferences in this captivating presentation. Explore the principles behind successful collaborations, understanding the advantages and disadvantages of this dynamic approach and how it can elevate your impact.\r\nGain insights into leveraging unique personalities and strengths, assessing the need for two speakers, and understanding the perception created, while incorporating engaging live code demonstrations and interactive elements.\r\nRecognize the importance of strong male allies in fostering inclusivity and integration. Harness the power of pair presenting to maximize your conference impact, forge meaningful connections, and empower you to make a lasting impression on your audience.",
+      "state": "closed",
+      "created_at": "2023-07-02T03:59:30Z",
+      "updated_at": "2023-10-01T23:05:47Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/210",
+      "comments": []
+    }
+  ],
+  "August 2023": [
+    {
+      "id": 1823402011,
+      "number": 215,
+      "title": "Dragonruby: Creating the game \"Metal Warrior: Search for Valhalla\"",
+      "description": "A lightening talk proposal (5mins) just going over some of the highlights and issues we had whilst creating a 2d action game called \"Metal Warrior: Search for Valhalla\".\r\n",
+      "state": "closed",
+      "created_at": "2023-07-27T00:31:58Z",
+      "updated_at": "2023-09-11T06:52:28Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/215",
+      "comments": [
+        {
+          "id": 1698280535,
+          "user": "map7",
+          "body": "Timed the talk last night, could go up to 10min, we'll see. I had a rough crowd to practice in front of (my kids)",
+          "created_at": "2023-08-29T23:41:21Z",
+          "updated_at": "2023-08-29T23:41:21Z"
+        },
+        {
+          "id": 1698425623,
+          "user": "ponny",
+          "body": "Super keen for this!",
+          "created_at": "2023-08-30T03:16:44Z",
+          "updated_at": "2023-08-30T03:16:44Z"
+        }
+      ]
+    },
+    {
+      "id": 1807154558,
+      "number": 212,
+      "title": "Talk Proposal: But why does it work?",
+      "description": "Description(this will appear on youtube): Nothing is a black box! Get the confidence to dive into unfamiliar code and languages, and understand how things really work. Join me on a deep dive into gems, the Ruby source code (and maybe more!)\r\n\r\nEstimated Talk Time: 15-30 min\r\n\r\nPreferred Month to Present: July 😱\r\n\r\nPreferred Social media handles: None\r\n\r\nMugshot (will be use in the slides): https://avatars.githubusercontent.com/u/1201065",
+      "state": "closed",
+      "created_at": "2023-07-17T07:24:28Z",
+      "updated_at": "2023-09-11T06:52:20Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/212",
+      "comments": [
+        {
+          "id": 1639110763,
+          "user": "simran-sawhney",
+          "body": "hey @rianmcguire - thanks for raising the issue mate. are you okay to do it in August if you need more time to prep, this way we would have locked in for next month ?",
+          "created_at": "2023-07-18T00:51:03Z",
+          "updated_at": "2023-07-18T00:51:03Z"
+        },
+        {
+          "id": 1641133189,
+          "user": "simran-sawhney",
+          "body": "hey @rianmcguire moving this to next month mate for August one - let's lock that in :) ",
+          "created_at": "2023-07-18T23:45:54Z",
+          "updated_at": "2023-07-18T23:45:54Z"
+        },
+        {
+          "id": 1681400974,
+          "user": "simran-sawhney",
+          "body": "Hey @rianmcguire - let's do it mate this month. I have added Milestone to it already :) ",
+          "created_at": "2023-08-16T23:39:48Z",
+          "updated_at": "2023-08-16T23:39:48Z"
+        }
+      ]
+    }
+  ],
+  "July 2023": [
+    {
+      "id": 1809022197,
+      "number": 214,
+      "title": "Tips for juniors and mentors",
+      "description": "1. reach out to the community and pair up with someone (Michael)\r\n2. exercism to brush up on some ruby\r\n3. basic TDD principles - via pairing\r\n4. look at some Dojo's\r\n5. take it to next level with curses!!! winner\r\n5-10 mins\r\nready for july 26th",
+      "state": "closed",
+      "created_at": "2023-07-18T03:44:24Z",
+      "updated_at": "2023-08-15T23:52:35Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/214",
+      "comments": []
+    },
+    {
+      "id": 1807364108,
+      "number": 213,
+      "title": "Proposal: a production bug 27 years in the making",
+      "description": "The most robustly tested application at the company. A PR to upgrade Ruby, weeks in the The tests passed on local and on CI. No issues detected on staging or the sandbox environment. All systems green.\r\n\r\nThen the production deploy started.\r\n\r\n---\r\n\r\nA time-traveling tale of how a confluence of changes came together to cause an issue in production.\r\n\r\nDuration: 10-15 minutes\r\nMonth: July 2023\r\n\r\n\r\n\r\n",
+      "state": "closed",
+      "created_at": "2023-07-17T09:29:17Z",
+      "updated_at": "2023-08-15T23:51:27Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/213",
+      "comments": [
+        {
+          "id": 1641132754,
+          "user": "simran-sawhney",
+          "body": "Let's do this next week on 26th July meetup!",
+          "created_at": "2023-07-18T23:45:17Z",
+          "updated_at": "2023-07-18T23:45:17Z"
+        },
+        {
+          "id": 1643233448,
+          "user": "radar",
+          "body": "Looking forward to it!",
+          "created_at": "2023-07-20T05:26:19Z",
+          "updated_at": "2023-07-20T05:26:19Z"
+        }
+      ]
+    },
+    {
+      "id": 1784401161,
+      "number": 209,
+      "title": "Talk Proposal: How FHIR is tackling a wicked problem with technical, social and political solutions",
+      "description": "Description (this will appear on YouTube): \r\n\r\nThe project of interoperability in healthcare is one that would make healthcare workers' jobs easier, our healthcare industry more efficient, and improve our experiences as patients. Yet, in spite of these upsides, the project has been held back by technical difficulty, a lack of cooperation and misaligned incentives. \r\n\r\nOne of the most promising developments in this space is HL7's FHIR standard, an extensible meta-model for exchanging healthcare data. Not only does FHIR offer some novel and fascinating techniques for flexibly modelling a wide range of data, it also engages in the community-building required to help it solve real problems, and the advocacy which is seeing it gain acceptance and mandate in national and international politics.\r\n\r\nThis talk will examine how Ruby developers can make productive use of FHIR in their projects, by describing the design of FHIR and the state of the tooling available to the Ruby ecosystem. Also discussed will be the lessons we can learn from FHIR on community-building and advocacy for our own technology solutions.\r\n\r\nEstimated Talk Time: 20 minutes\r\n\r\nPreferred Month to Present: July '23\r\n\r\nPreferred Social Media Handles: matthood0@gmail.com\r\n\r\nMugshot (will be used in the slides):\r\n![mattbio](https://github.com/rubyaustralia/melbourne-ruby/assets/1885706/ebc7dec6-6fb4-4042-968e-b860ed8ef3f7)\r\n",
+      "state": "closed",
+      "created_at": "2023-07-02T02:44:01Z",
+      "updated_at": "2023-08-15T23:52:48Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/209",
+      "comments": [
+        {
+          "id": 1639046895,
+          "user": "simran-sawhney",
+          "body": "hey @MattHood we have added **July talk** milestone for this issue , see you then!",
+          "created_at": "2023-07-17T23:48:00Z",
+          "updated_at": "2023-07-17T23:48:24Z"
+        }
+      ]
+    }
+  ],
+  "RORO June 2021": [
+    {
+      "id": 913030143,
+      "number": 175,
+      "title": "Lightning talk: How to stop I18n getting complex",
+      "description": "10 minutes. \r\nIn Rails, I18n gets confusing :( I'm always trying to figure out where keys come from and what text methods return. \r\n\r\nMy team and I have done some cool stuff to keep it simple. I've never seen it done like this before, so I'd like to share it.",
+      "state": "closed",
+      "created_at": "2021-06-07T02:19:32Z",
+      "updated_at": "2021-07-05T11:24:38Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/175",
+      "comments": [
+        {
+          "id": 855805793,
+          "user": "optimistic-updt",
+          "body": "Hey @davich,\r\n\r\nThat sounds great.\r\nWould you be willing to share at this month's RORO (30th June)?\r\n\r\nLet me know",
+          "created_at": "2021-06-07T10:22:27Z",
+          "updated_at": "2021-06-07T10:22:27Z"
+        },
+        {
+          "id": 859133604,
+          "user": "davidcarlin-ap",
+          "body": "Yep, can do. Will it be in person or zoom?",
+          "created_at": "2021-06-10T22:47:42Z",
+          "updated_at": "2021-06-10T22:47:42Z"
+        },
+        {
+          "id": 859375930,
+          "user": "davich",
+          "body": "ha, that's also me ^^. On my work github account. Probably confusing to the casual observer.",
+          "created_at": "2021-06-11T08:13:02Z",
+          "updated_at": "2021-06-11T08:13:02Z"
+        },
+        {
+          "id": 861851031,
+          "user": "optimistic-updt",
+          "body": "haha no problem @davich / @davidcarlin-ap.\r\nShould your talk be titled: How to stop I18n getting complex\r\n?",
+          "created_at": "2021-06-15T21:38:17Z",
+          "updated_at": "2021-06-15T21:43:54Z"
+        },
+        {
+          "id": 864540719,
+          "user": "davich",
+          "body": "yep, that's a descriptive title. Will the meetup be in person or zoom?",
+          "created_at": "2021-06-20T11:40:23Z",
+          "updated_at": "2021-06-20T11:40:23Z"
+        },
+        {
+          "id": 869236282,
+          "user": "optimistic-updt",
+          "body": "Meetup will be over Zoom @davich \r\n:)",
+          "created_at": "2021-06-27T23:02:45Z",
+          "updated_at": "2021-06-27T23:02:45Z"
+        }
+      ]
+    },
+    {
+      "id": 839473136,
+      "number": 174,
+      "title": "Exercism for Junior Developers",
+      "description": "Hi guys, I recently completed a bootcamp from Le Wagon. \r\n\r\nI have experienced that most bootcamp graduate lack the understanding of test driven development as well as how to conduct pair programming coding challenge. I would like to present 2 exercism exercise to showcase how to approach a problem.\r\n\r\nI am also participating in the presentation to build confidence around technical gurus.",
+      "state": "closed",
+      "created_at": "2021-03-24T08:21:17Z",
+      "updated_at": "2021-07-05T11:24:38Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/174",
+      "comments": [
+        {
+          "id": 822394701,
+          "user": "optimistic-updt",
+          "body": "Hey @achhetr, Thank you for reaching and well done for putting yourself out there!!\r\nWould you be keen to Present at the April RORO on the 28th (next week)?\r\n How long would your talk be?\r\n \r\n Thank you",
+          "created_at": "2021-04-19T11:28:28Z",
+          "updated_at": "2021-04-19T11:28:28Z"
+        },
+        {
+          "id": 822925361,
+          "user": "achhetr",
+          "body": "Thank you @CumulusGround for giving me this opportunity. I am planning to give 15 to 20 mins talk. \r\nI have two ideas which I am happy to share with young developers. \r\n1) 2 exercism exercise to showcase how to approach a problem\r\n2) How to integrate React with Rails\r\n\r\nPlease suggest which one should I go as I think they both are really important",
+          "created_at": "2021-04-20T02:29:07Z",
+          "updated_at": "2021-04-20T02:29:07Z"
+        },
+        {
+          "id": 823092634,
+          "user": "optimistic-updt",
+          "body": "Hey @achhetr,\r\n\r\nthey do both sound great!!\r\nbut obviously I'm mindful of having a couple of speakers on the night.\r\n\r\nHow about this:\r\nWe can do React/Ruby this time\r\nthen skip next month\r\nthen have you back in June for the exersim one.\r\n\r\nMy thought behind it is that I think a lot of bootcamp just started in March and should wrap up in June, which theoretically would give us an influx of junior, perfect target crowd for the exercism.\r\n\r\nwhat do you think?\r\n\r\nCheers\r\n",
+          "created_at": "2021-04-20T08:36:43Z",
+          "updated_at": "2021-04-20T08:36:43Z"
+        },
+        {
+          "id": 823096739,
+          "user": "achhetr",
+          "body": "Sounds great @CumulusGround\r\n\r\nThis will be my first presentation, have you got any tips which I can offer to the audience from React on Rails perspective",
+          "created_at": "2021-04-20T08:42:36Z",
+          "updated_at": "2021-04-20T08:42:36Z"
+        }
+      ]
+    }
+  ],
+  "March 2021": [
+    {
+      "id": 839194785,
+      "number": 173,
+      "title": "The Joy of Docs: Technical Writing for Developers and Engineers",
+      "description": "Hello organisers! I would like to propose a talk about technical writing. You can see the slide deck [here](https://docs.google.com/presentation/d/1somOY_01ZRgSxuAIX-RenImp9QkgytjpXwsKm91lYoo/edit?usp=sharing) if you'd like to suss it out more, but here's the gist. I can be available any Wednesday but need at least a few days' advance notice to let my D&D group know I won't be there :)\r\n\r\n## Talk Title\r\n\r\nThe Joy of Docs: Technical Writing for Developers and Engineers\r\n\r\n## Description\r\n\r\nIn this talk, I discuss communication, specifically technical writing, why it's important, and how to improve your skills. Emphasis is on identifying and empathising with your audience. The talk does not strictly cover the writing process as it is taught in schools, but rather focusses on orienting oneself towards readers' needs when writing technical documents or producing other technical writing. The information in this talk is applicable to any kind of technical writing, from commit messages to requests for comment (RFCs), as well as technical writing that is not strictly a part of a technical document (e.g., writing in an email to stakeholders about the status of development on a project). \r\n\r\n## Why It's Important\r\n\r\nBad technical writing is a huge waste of time. Every developer who's worked in the industry for any length of time has encountered vague and unhelpful documentation and seen how much time they spend trying to find information that should've been in the docs in the first place. Engineers who read RFCs and other longer-form documents may notice these documents often don't give adequate context or define terms, leading to more time spent on research rather than focussing on the tasks at hand.",
+      "state": "closed",
+      "created_at": "2021-03-23T23:08:03Z",
+      "updated_at": "2021-04-14T00:19:53Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/173",
+      "comments": [
+        {
+          "id": 806226489,
+          "user": "optimistic-updt",
+          "body": "Hi Dana, \r\nThank you for proposing this talk!\r\n\r\nIt sounds like a great talk and it's definitely already right at home with me :) :S\r\n\r\nHow long do you thing your talk would take? \r\nThe next RORO is next wednesday the 31st of March.\r\n\r\nWould you be keen/ready to present then?\r\n\r\nCheers\r\n",
+          "created_at": "2021-03-24T22:30:07Z",
+          "updated_at": "2021-03-24T22:32:02Z"
+        },
+        {
+          "id": 806327553,
+          "user": "oscaralanpierce",
+          "body": "The 31st works! The last time I gave this talk it ran about 30 minutes but I can make it longer or shorter to suit. Just let me know!",
+          "created_at": "2021-03-25T03:00:51Z",
+          "updated_at": "2021-03-25T03:00:51Z"
+        },
+        {
+          "id": 808849971,
+          "user": "optimistic-updt",
+          "body": "awesome, 31st it is then.\r\nWe'll be in touch with you shortly",
+          "created_at": "2021-03-28T05:31:00Z",
+          "updated_at": "2021-03-28T05:31:00Z"
+        },
+        {
+          "id": 819132356,
+          "user": "optimistic-updt",
+          "body": "https://youtu.be/l8pFr1y14f8",
+          "created_at": "2021-04-14T00:19:53Z",
+          "updated_at": "2021-04-14T00:19:53Z"
+        }
+      ]
+    }
+  ],
+  "February 2021 meetup": [
+    {
+      "id": 813929810,
+      "number": 172,
+      "title": "View Components in the Wild",
+      "description": "Just some examples of how we at [Fresho](http://fresho.com) are using [View Components](https://viewcomponent.org/) to test rails views and help us decompose the front end, it will be wild! With the better design through composability, leading to simplifying testing and more consistent front ends.\r\n\r\ninspired by https://github.com/rails-oceania/melbourne-ruby/issues/158\r\n\r\npresented from https://github.com/failure-driven/view-components-in-the-wild\r\n\r\nready for Feb 2021 - ie like tomorrow",
+      "state": "closed",
+      "created_at": "2021-02-22T22:47:58Z",
+      "updated_at": "2021-03-28T10:07:58Z",
+      "url": "https://github.com/rubyaustralia/melbourne-ruby/issues/172",
+      "comments": [
+        {
+          "id": 808875142,
+          "user": "VanessaNimmo",
+          "body": "https://youtu.be/ISWuPcCoChw 🌄",
+          "created_at": "2021-03-28T10:07:58Z",
+          "updated_at": "2021-03-28T10:07:58Z"
+        }
+      ]
+    }
+  ]
+}

--- a/sites/melbourne/lib/melbourne/data/prompt.md
+++ b/sites/melbourne/lib/melbourne/data/prompt.md
@@ -1,0 +1,133 @@
+You are a helpful data analyst and writer that can easily read data in json format and extract insights from it.
+You also have great writing skills and are well versed in writing content for event websites to make it engaging and fun.
+
+This is a sample of an input you will receive. It contains data in json format with a date of when a meetup happened and the talks that
+happened that day.
+
+### Example input
+
+```json
+{
+  "date": "2025-05-29",
+  "talks": [
+    {
+      "id": 2950841633,
+      "title": "Requested talk: How on earth do you manage forms with Turbo?",
+      "description": "Turbo is an amazing tool that usually stays out of the way. Forms, however, come with some weird and wonderful quirks that can drive you insane.\n\nI'd love to hear a talk that covers things like:\n\n- Handling errors\n  - Status codes\n  - Double rendering\n- Redirecting after a form submission (esp when used inside a Turbo Frame)\n- Disabling Turbo on a form\n- Leveraging Turbo Streams\n- Inline validations and dynamic error messaging\n- Testing Turbo interactions",
+      "comments": [
+        {
+          "github_username": "MattHood",
+          "body": "This is close to my heart, and I'm keen to do another RORO talk, so I'd love to pick this one up.\n\nIf anyone else is keen to get into this topic, feel free to get in touch - would be lovely to have a collaborator :)"
+        },
+        {
+          "github_username": "HashNotAdam",
+          "body": "This would make me very happy, @MattHood 🫶"
+        },
+        {
+          "github_username": "simran-sawhney",
+          "body": "Thanks @MattHood for the great showcase!"
+        }
+      ]
+    },
+    {
+      "id": 2937083767,
+      "title": "Talk Proposal: SQLite-ruby - a whole SQL database in a gem",
+      "description": "SQLite - the most deployed database that most people have never heard of - as a gem\n\nEstimated Talk Time: 5-20 minutes\n\nPrefered Month to Present: -\n\nPreferred Social media handles: @apocraphilia@hachyderm.io\n\n\n",
+      "comments": [
+        {
+          "github_username": "HashNotAdam",
+          "body": "Can't believe I didn't think to add this as a requested talk. SQLite is so hot right now! Brilliant topic"
+        },
+        {
+          "github_username": "simonhildebrandt",
+          "body": "When do you think we should do it?"
+        },
+        {
+          "github_username": "simran-sawhney",
+          "body": "Hey @simonhildebrandt we can do this May if you like ? "
+        },
+        {
+          "github_username": "simonhildebrandt",
+          "body": "Sure - I'm in no rush if we wanna give other people a go, though. 😁 "
+        },
+        {
+          "github_username": "dkam",
+          "body": "I’m happy to do this for May, if Simon’s ok with that? I’d be aiming for a regular length talk rather than a lightning talk though. "
+        },
+        {
+          "github_username": "simonhildebrandt",
+          "body": "That'd be awesome, @dkam !\n"
+        },
+        {
+          "github_username": "simran-sawhney",
+          "body": "Hey @dkam, are you planning to go for this one this month? \nSince we don’t have much lined up, I guess we could go for a proper talk instead lightning talk!\n\n"
+        },
+        {
+          "github_username": "simran-sawhney",
+          "body": "Thanks @dkam for the amazing talk :) "
+        }
+      ]
+    }
+  ]
+}
+```
+
+Your task is to:
+- Read all the data provided
+- From the description and the comments:
+  - figure out who the speaker or speakers were for a given talk and remember their name
+  - figure out any social media handles they might have provided and remember them
+  - figure out if they provided a link to their webiste and remember it
+    - make sure that the url is for something that resembles a personal webiste. if it is a linkedin url, instagram url, twitter/x url, bluesky url or a mastodon url, extract the handle from it and remember it as a social media handle.
+  - create a short summary (no longer than 300 characters) of what a meetup talk will be about. Make it slightly cheerful and inviting; as if you were inviting people to see the talk live.
+  - create a slug to represent the web page the event will live on and remember it. Keep it under 70 characters
+  - create a name for the event. Keep it around 60 characters. Make sure to include the topics and the speakers.
+
+You should then use that information you've extracted to return a new JSON file. This is an example of the expected output from the sample above
+
+```json
+{
+  "date": "2025-05-29",
+  "name": "Forms and Turbo with Matt Hood and SQLite in Rails with Simon Hildebrandt",
+  "description": "Learn how to handle complex forms with Turbo with Matt Hood. Then, dive into the world of SQLite with Simon",
+  "slug": "2025-5-29-turbo-and-sqlite",
+  "talks": [
+    {
+      "title": "How on earth do you manage forms with Turbo?",
+      "description": "Join us for a fun dive into Turbo forms! We'll tackle those quirky challenges that make you pull your hair out - from error handling and redirects to streams and validations. Learn the tricks to tame form weirdness and make Turbo work beautifully! 🚀",
+      "speakers": [
+        {
+          "name": "Matt Hood",
+          "contact_details": {
+            "github_username": "MattHood",
+            "x_handle": null,
+            "linkedin_handle": null,
+            "bluesky_handle": null,
+            "mastodon_handle": null,
+            "website": null
+          }
+        }
+      ]
+    },
+    {
+      "title": "SQLite-ruby - a whole SQL database in a gem",
+      "description": "SQLite - the most deployed database that most people have never heard of - as a gem",
+      "speakers": [
+        {
+          "name": "Simon Hildebrandt",
+          "contact_details": {
+            "github_username": "simonhildebrandt",
+            "x_handle": null,
+            "linkedin_handle": null,
+            "bluesky_handle": null,
+            "mastodon_handle": "@apocraphilia@hachyderm.io",
+            "website": null
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+Now, process the following json with the instructions given:

--- a/sites/melbourne/lib/melbourne/engine.rb
+++ b/sites/melbourne/lib/melbourne/engine.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Melbourne
+  class Engine < Rails::Engine
+    isolate_namespace Melbourne
+
+    root.join("lib").tap do |lib|
+      config.autoload_paths << lib.to_s
+      config.eager_load_paths << lib.to_s
+    end
+
+    routes.default_url_options = { host: "localhost", port: 3000, subdomain: "melbourne" }
+  end
+end

--- a/sites/melbourne/lib/melbourne/github/issue_fetcher.rb
+++ b/sites/melbourne/lib/melbourne/github/issue_fetcher.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+module Melbourne
+  module Github
+    class IssueFetcher
+      def initialize(github_token:, repo_owner:, repo_name:)
+        @github_token = github_token
+        @repo_owner = repo_owner
+        @repo_name = repo_name
+      end
+
+      def fetch_all
+        issues = fetch_issues
+        group_by_milestone(issues)
+      end
+
+      private
+
+      attr_reader :github_token, :repo_owner, :repo_name
+
+      def fetch_issues # rubocop:disable Metrics/AbcSize
+        uri = URI("https://api.github.com/repos/#{repo_owner}/#{repo_name}/issues")
+        uri.query = URI.encode_www_form(state: 'all', per_page: 100)
+
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = true
+
+        request = Net::HTTP::Get.new(uri)
+        request['Authorization'] = "token #{github_token}"
+        request['Accept'] = 'application/vnd.github.v3+json'
+
+        response = http.request(request)
+
+        raise "Error fetching issues: #{response.code} - #{response.body}" unless response.code == '200'
+
+        JSON.parse(response.body)
+      end
+
+      def fetch_comments(issue_number) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+        uri = URI("https://api.github.com/repos/#{repo_owner}/#{repo_name}/issues/#{issue_number}/comments")
+
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = true
+
+        request = Net::HTTP::Get.new(uri)
+        request['Authorization'] = "token #{github_token}"
+        request['Accept'] = 'application/vnd.github.v3+json'
+
+        response = http.request(request)
+
+        raise "Error fetching comments for issue #{issue_number}: #{response.code}" unless response.code == '200'
+
+        comments = JSON.parse(response.body)
+        comments.map do |comment|
+          {
+            id: comment['id'],
+            user: comment['user']['login'],
+            body: comment['body'],
+            created_at: comment['created_at'],
+            updated_at: comment['updated_at']
+          }
+        end
+      end
+
+      def group_by_milestone(issues) # rubocop:disable Metrics/MethodLength
+        grouped = {}
+
+        issues.each do |issue|
+          milestone_name = issue['milestone'] ? issue['milestone']['title'] : 'No Milestone'
+
+          grouped[milestone_name] ||= []
+
+          comments = fetch_comments(issue['number'])
+
+          grouped[milestone_name] << {
+            id: issue['id'],
+            number: issue['number'],
+            title: issue['title'],
+            description: issue['body'],
+            state: issue['state'],
+            created_at: issue['created_at'],
+            updated_at: issue['updated_at'],
+            url: issue['html_url'],
+            comments: comments
+          }
+        end
+
+        grouped
+      end
+    end
+  end
+end

--- a/sites/melbourne/lib/tasks/data_processing.rake
+++ b/sites/melbourne/lib/tasks/data_processing.rake
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+namespace :melbourne do
+  namespace :data do
+    desc "fetch issues from melbourne-ruby"
+    task :fetch_issues, [:repo_owner, :repo_name, :github_token] => :environment do
+      raise unless Rails.env.development?
+
+      repo_owner = args[:repo_owner] # rubyaustralia
+      repo_name = args[:repo_name] # melbourne-ruby
+      github_token = args[:github_token]
+
+      fetcher = Melbourne::Github::IssueFetcher.new(
+        github_token:,
+        repo_owner:,
+        repo_name:
+      )
+
+      result = fetcher.fetch_all
+
+      no_milestone = result.delete("No Milestone")
+
+      File.write(Melbourne::Engine.root.join("lib", "melbourne", "data", "output", "events", "raw", "issues.json"), JSON.pretty_generate(result.as_json))
+      File.write(Melbourne::Engine.root.join("lib", "melbourne", "data", "output", "events", "raw", "issues-no-milestone.json"), JSON.pretty_generate(no_milestone.as_json))
+    end
+
+    desc "cleanup data for LLMs"
+    task cleanup_data: :environment do
+      result = Melbourne::Data::LLMPreparer.new(path: "#{Melbourne::Engine.root}/db/data/events/raw/issues.json").prepare
+
+      File.write(
+        Melbourne::Engine.root.join("lib", "melbourne", "data", "output", "events", "processed", "1_llm_meetups_data.json"),
+        JSON.pretty_generate(result)
+      )
+    end
+
+    desc "send request to LLM"
+    task process_with_llms: :environment do
+      caller = Melbourne::Data::LLMCaller.new(openai_api_key: ENV["OPENAI_API_KEY"])
+      result = caller.call(path: File.read(Melbourne::Engine.root.join("lib", "melbourne", "data", "output", "events", "processed", "1_llm_meetups_data.json")))
+      File.write(
+        Melbourne::Engine.root.join("lib", "melbourne", "data", "output", "events", "processed", "2_llm_interpretation.json"),
+        JSON.pretty_generate(result)
+      )
+    end
+
+    desc "process issues; from json to yaml in event format"
+    task process_into_domain_models: :environment do
+      path = "#{Melbourne::Engine.root}/lib/melbourne/data/output/events/processed/2_llm_interpretation.json"
+      processor = Melbourne::Data::DomainModelProcessor.new(path:)
+      events = processor.process
+      File.write(
+        Melbourne::Engine.root.join("lib", "melbourne", "data", "output", "events", "processed", "3_data_in_app_domain.yml"),
+        events.to_yaml
+      )
+    end
+  end
+end

--- a/sites/melbourne/spec/models/melbourne/event_spec.rb
+++ b/sites/melbourne/spec/models/melbourne/event_spec.rb
@@ -1,0 +1,144 @@
+require "rails_helper"
+
+RSpec.describe Melbourne::Event do
+  describe ".all" do
+    it "returns all events, sorted by date descending" do
+      events = described_class.all
+      expect(events).to be_an(Array)
+
+      first_event = events.first
+      expect(first_event).to be_a(described_class)
+      expect(first_event.venue).to be_a(Melbourne::Event::Venue)
+      expect(first_event.talks).to be_an(Array)
+      expect(first_event.talks.first).to be_a(Melbourne::Event::Talk)
+      expect(first_event.talks.first.speakers.first).to be_a(Melbourne::Event::Speaker)
+    end
+
+    describe "validate YML db data" do
+      it "is valid" do
+        described_class.all.each do |event| # rubocop:disable Rails/FindEach
+          puts "Validating event: #{event.uuid}"
+          expect(event.valid?).to be(true)
+          puts "Validating venue: #{event.venue.name}"
+          expect(event.venue.valid?).to be(true)
+          event.talks.each do |talk|
+            puts "Validating talk: #{talk.uuid}"
+            expect(talk.valid?).to be(true)
+            talk.speakers.each do |speaker|
+              puts "Validating speaker: #{speaker.name}"
+              expect(speaker.valid?).to be(true)
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe ".find_by_slug" do
+    subject(:event) { described_class.all.first }
+
+    it "returns the event with the matching slug" do
+      found_event = described_class.find_by_slug(event.slug) # rubocop:disable Rails/DynamicFindBy
+      expect(found_event.slug).to eq(event.slug)
+    end
+  end
+
+  describe "#to_param" do
+    it "returns the slug" do
+      event = described_class.new(slug: "hello-123")
+      expect(event.to_param).to eq("hello-123")
+    end
+  end
+
+  describe "#schema" do
+    it "returns the event schema" do # rubocop:disable RSpec/ExampleLength
+      event = described_class.new(
+        slug: "2025-04-24-make-vs-justfile-vs-mise-rails-8-new",
+        date: Date.new(2025, 4, 24),
+        name: "Name of the event",
+        description: "Make vs justfile vs mise and Rails 8 new with Michael Milewski and John Sherwood.",
+        venue: Melbourne::Event::Venue.new(
+          name: "BOYD Community Hub",
+          address: {
+            street: "207 City Rd",
+            locality: "Southbank",
+            postal_code: '3006',
+            region: "VIC",
+            country: "AU",
+          }
+        ),
+        talks: [
+          Melbourne::Event::Talk.new(
+            title: "Make vs justfile vs mise",
+            speakers: [Melbourne::Event::Speaker.new(name: "Michael Milewski")]
+          ),
+          Melbourne::Event::Talk.new(
+            title: "Rails 8 new",
+            speakers: [Melbourne::Event::Speaker.new(name: "John Sherwood")]
+          )
+        ]
+      )
+      expect(event.schema).to \
+        eq({
+             "@context" => "https://schema.org",
+             "@type" => "Event",
+             name: "Name of the event",
+             description: "Make vs justfile vs mise and Rails 8 new with Michael Milewski and John Sherwood.",
+             start_date: Time.new(2025, 4, 24, 18).iso8601,
+             end_date: Time.new(2025, 4, 24, 20, 30).iso8601,
+             event_status: "https://schema.org/EventScheduled",
+             location: {
+               "@type" => "Place",
+               name: "BOYD Community Hub",
+               address: {
+                 "@type" => "PostalAddress",
+                 street_address: "207 City Rd",
+                 address_locality: "Southbank",
+                 postal_code: "3006",
+                 address_region: "VIC",
+                 address_country: "AU"
+               }
+             },
+             performers: [
+               {
+                 "@type" => "Person",
+                 name: "Michael Milewski"
+               },
+               {
+                 "@type" => "Person",
+                 name: "John Sherwood"
+               }
+             ]
+           })
+    end
+  end
+
+  describe "#open_graph_metadata" do
+    it "returns the event open graph metadata" do
+      event = described_class.new(
+        name: "The event name",
+        slug: "2025-04-24-make-vs-justfile-vs-mise-rails-8-new",
+        date: Date.new(2025, 4, 24),
+        description: "Make vs justfile vs mise and Rails 8 new with Michael Milewski and John Sherwood.",
+      )
+      expect(event.open_graph_metadata).to \
+        eq({
+             title: "2025-04-24 - The event name",
+             description: "Make vs justfile vs mise and Rails 8 new with Michael Milewski and John Sherwood.",
+             keywords: "Events, Ruby, Rails, Melbourne",
+             og: {
+               title: :title,
+               description: :description,
+               image: nil,
+               url: "http://melbourne.localhost:3000/events/2025-04-24-make-vs-justfile-vs-mise-rails-8-new",
+             },
+             twitter: {
+               card: "summary",
+               site: "@rubyau",
+               title: :title,
+               description: :description,
+             }
+           })
+    end
+  end
+end

--- a/sites/melbourne/spec/requests/melbourne/home_controller_spec.rb
+++ b/sites/melbourne/spec/requests/melbourne/home_controller_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe Melbourne::HomeController, type: :request do
+  before do
+    host! "melbourne.example.com"
+  end
+
+  describe "show" do
+    it "displays the home page" do
+      get melbourne.root_path
+      expect(response.status).to eq(200)
+      expect(response.body).to include("Ruby Melbourne is a")
+      expect(response.body).to include("Ruby Australia Meetup")
+      expect(response.body).to include("Ruby Melbourne")
+    end
+  end
+end


### PR DESCRIPTION
This PR creates all the basic structures to deploy a site on a subdomain. As a first example, it sets up the Ruby Melbourne website. 

# How to review this PR
>[!note]
> 45 files and +7800 lines Juli? Are you cray cray?
> It looks daunting but most of those lines and files are attributed to the data processing objects, schemas and prompts used to clean up data using LLMs. You can safely ignore them because they are not used in the app at all. Their sole purpose was to create the database at `events.yml`. 

<img width="464" height="365" alt="image" src="https://github.com/user-attachments/assets/11523093-2c16-4fbf-851c-dcc2d3b3f72d" />


It's best to review this PR per commit. Each one has a distinct purpose and incrementally adds more functionality. I would not review the data processing commit because at the end, what really matters is the `event.yml` file and that's it. I left it there because I think it provides a nice open source example of how to deal with cleaning up data using LLMs and might be helpful in the future to future travellers.

# About the structure

## Sites as separate lean "engines"
In order to separate the websites from the main app, I used the techniques [I presented at RubyConf AU 2023](https://www.youtube.com/watch?v=StDoHXO8H6E&list=PL9_jjLrTYxc0s-zA-RxRyb62tIcugZyG3&index=5) that use engines to modularise apps. You'll find a `sites` directory that's a sibling of `app`. In it you'll find `sites/melboure` that holds the Ruby Melbourne website. The file structure is exactly the same as any Rails app.

## Database as YML entries for now
Until we discover the right shape of this data, I created a database in plain YML we can use for now.

### Data processing
All of this data comes from the milestones from the [Ruby Melbourne GitHub issues](https://github.com/rubyaustralia/melbourne-ruby/milestones?state=closed) page. The data was:
1. pulled from GItHub
2. cleaned up
3. sent to Open AI to summarise and find the speakers for each talk
4. cleaned up again and formatted for the consumption of the models of the app

## Models
This version uses ActiveModel to wrap the YML entries. We'll be able to migrate to ActiveRecord easily in the future once we discover what the right shape of data is for our websites.

```mermaid
erDiagram
    EVENT {
        string uuid PK
        date date
        string summary
        string slug
        string type
        venue venue
        talks talks
    }
    
    VENUE {
        string name
        string google_maps_url
        object address
    }
    
    TALK {
        string uuid PK
        string title
        string description
        string video_url
        array speakers
    }
    
    SPEAKER {
        string name
        object contact_details
    }
    
    EVENT_SCHEMA {
        string context
        string type
        string name
        string start_date
        string end_date
        string event_status
        object location
        string description
        array performers
    }
    
    VENUE_SCHEMA {
        string type
        string name
        object address
    }
    
    SPEAKER_SCHEMA {
        string type
        string name
    }
    
    OPEN_GRAPH_METADATA {
        string title
        string description
        string keywords
        object og
        object twitter
    }
    
    %% Relationships
    EVENT ||--|| VENUE : has
    EVENT ||--o{ TALK : contains
    TALK ||--o{ SPEAKER : features
    
    %% Schema relationships
    EVENT ||--|| EVENT_SCHEMA : generates
    VENUE ||--|| VENUE_SCHEMA : generates
    SPEAKER ||--|| SPEAKER_SCHEMA : generates
    EVENT ||--|| OPEN_GRAPH_METADATA : generates
    
    %% Nested relationships for schema
    EVENT_SCHEMA ||--|| VENUE_SCHEMA : includes_location
    EVENT_SCHEMA ||--o{ SPEAKER_SCHEMA : includes_performers
```

### Schema and Metadata

This PR also adds two key classes to generate schema and metadata for each event's page. Schema classes handle [google search result indexing of events](https://developers.google.com/search/docs/appearance/structured-data/event) and the open graph metadata class does what it says on the tin; handle open graph metadata.

You'll note that none of these classes have tests. You'll also note I've made them private constants. This is a signal to consumers that these classes aren't meat to be used directly and that they are tested elsewhere. The `Melbourne::Event` class has a test for `schema` which tests the whole schema, including Venue and Speakers and a test for the open graph metadata.

## Gems
I added the [meta-tags gem](https://github.com/kpumuk/meta-tags) which makes it pretty easy to generate meta tags for social sharing purposes. 

## Assets
I tried configuring vite to pull assets from inside the Melbourne website but I was pretty hard. I decided to punt that and compile a new stylesheet just for Melbourne to allow it to have its own identity. We can come back to this in the future and explore other possibilities 

## CI and tests
- I updated the bin/test scrip and our CI scripts to also run the specs in the sites folder from now on
- the Melbourne site has its own specs within he sites/melbourne folder.

## A note on views
For now, this PR adds some basic views that are not the final website. We're working on that on a separate branch. I wanted to get ahead and merge these changes and make the DNS changes first before deploying the complete new design. For now, it just looks exactly like the melbourne.ruby.org.au look today.

<img width="1512" height="846" alt="image" src="https://github.com/user-attachments/assets/0184b134-b60a-4785-8c5c-325546de4a45" />

# Important changes
In order to use subdomains I've configure the TLD settings for both development and production. This is the only change I want to be cautious about.

# How to test it
Run `bin/dev` and visit melbourne.localhost:3000 in Chrome or Firefox. Safari does not support using subdomains on localhost yet unfortunately.