### PR TITLE
Remove pigmentize from melbourne website

### DIFF
--- a/sites/melbourne/app/views/melbourne/home/show.html.erb
+++ b/sites/melbourne/app/views/melbourne/home/show.html.erb
@@ -14,14 +14,14 @@
     <div class="col-start-2">
       <div class="flex bg-[#0025CA] rounded-t h-full items-center px-4 overflow-auto">
         <code class="text-sm">
-          <%= raw Pygmentize.process("render collection: @latest_events, partial: \"home/event\"", :ruby) %>
+          <%# raw Pygmentize.process("render collection: @latest_events, partial: \"home/event\"", :ruby) %>
         </code>
       </div>
     </div>
     <div class="col-start-3">
       <div class="flex bg-[#0025CA] rounded-t h-full items-center px-4  overflow-auto">
         <code class="text-sm">
-          <%= raw Pygmentize.process("render \"home/next_event\", event: @next_event", :ruby) %>
+          <%# raw Pygmentize.process("render \"home/next_event\", event: @next_event", :ruby) %>
         </code>
       </div>
     </div>


### PR DESCRIPTION
This is an attempt to figure out if the deployment failed because of this. It works OK in development but I've seen a few instances of this not quite working in other envs.

It's strange the deployment didn't work though because the review app deployed just fine