### PR TITLE
Use rouge for syntax highlighting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,3 +87,4 @@ end
 gem 'tzinfo-data', platforms: [:windows, :jruby]
 
 gem "meta-tags", "~> 2.22"
+gem "rouge"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -395,6 +395,7 @@ GEM
       actionpack (>= 5.2)
       railties (>= 5.2)
     rexml (3.4.1)
+    rouge (4.6.0)
     rspec (3.13.1)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -590,6 +591,7 @@ DEPENDENCIES
   rails-controller-testing
   rails_12factor
   redcarpet
+  rouge
   rspec-rails
   rubocop
   rubocop-capybara

--- a/sites/melbourne/app/views/melbourne/home/show.html.erb
+++ b/sites/melbourne/app/views/melbourne/home/show.html.erb
@@ -1,3 +1,8 @@
+<%
+  formatter = Rouge::Formatters::HTML.new
+  lexer = Rouge::Lexers::Ruby.new
+%>
+
 <% set_meta_tags title: "Home",
                  description: "Ruby community in Melbourne hosting meetups, workshops, hack nights, Rails Girls and more events to learn Ruby and grow the community.",
                  keywords: "Ruby, Rails, Melbourne, Meetup",
@@ -13,15 +18,15 @@
   <div class="hidden md:grid col-span-4 grid-cols-subgrid bg-blue-700 h-8 gap-16">
     <div class="col-start-2">
       <div class="flex bg-[#0025CA] rounded-t h-full items-center px-4 overflow-auto">
-        <code class="text-sm">
-          <%# raw Pygmentize.process("render collection: @latest_events, partial: \"home/event\"", :ruby) %>
+        <code class="text-sm highlight overflow-auto whitespace-nowrap">
+          <%== formatter.format(lexer.lex("render collection: @latest_events, partial: \"home/event\"")) %>
         </code>
       </div>
     </div>
     <div class="col-start-3">
       <div class="flex bg-[#0025CA] rounded-t h-full items-center px-4  overflow-auto">
-        <code class="text-sm">
-          <%# raw Pygmentize.process("render \"home/next_event\", event: @next_event", :ruby) %>
+        <code class="text-sm highlight overflow-auto whitespace-nowrap">
+          <%== formatter.format(lexer.lex("render \"home/next_event\", event: @next_event")) %>
         </code>
       </div>
     </div>


### PR DESCRIPTION
As suspected in https://github.com/rubyaustralia/ruby_au/pull/325, Pigmentize was causing issues. I've installed rouge, which is widely used an well maintained