### PR TITLE
🔝 Rearrange sponsor order

### DIFF
--- a/config/data/sponsors.yml
+++ b/config/data/sponsors.yml
@@ -1,3 +1,12 @@
+- name: Assembly Four
+  key: assemblyfour
+  url: https://assemblyfour.com/
+  images:
+    - 2024/assembly-four-500x143.png
+  tier: Sapphire
+  bio: |
+    [Assembly Four](https://assemblyfour.com) is a collective of sex workers and technologists on a mission to empower sex workers through technology. Sex workers are among the most marginalised, stigmatised groups in the world, and our goal is to create platforms where sex workers thrive, not just survive.
+
 - name: Bluethumb
   key: bluethumb
   url: https://bluethumb.com.au/
@@ -7,11 +16,3 @@
   bio: |
     Bluethumb's mission is to create the world's largest online art marketplace by transforming the way art is bought and sold. We connect artists with collectors nationwide and have recently expanded our platform to the US.
 
-- name: Assembly Four
-  key: assemblyfour
-  url: https://assemblyfour.com/
-  images:
-    - 2024/assembly-four-500x143.png
-  tier: Sapphire
-  bio: |
-    [Assembly Four](https://assemblyfour.com) is a collective of sex workers and technologists on a mission to empower sex workers through technology. Sex workers are among the most marginalised, stigmatised groups in the world, and our goal is to create platforms where sex workers thrive, not just survive.


### PR DESCRIPTION
This PR rearranges the order the sponsors are listed so that Sapphire Sponsors are listed before Opal.

### BEFORE

<img width="1856" height="1213" alt="Screenshot 2025-08-14 at 5 16 15 PM" src="https://github.com/user-attachments/assets/4e21a0b1-b8c6-49d9-ace0-646acdbd0485" />

### AFTER

<img width="1909" height="1228" alt="Screenshot 2025-08-17 at 12 15 36 PM" src="https://github.com/user-attachments/assets/87de498a-af56-4dcf-bb26-cea6f2230ab2" />
