### PR TITLE
Replace "Rails Camp" with "Ruby Retreat"

### DIFF
--- a/app/documents/policies/code_of_conduct_enforcement.markdown
+++ b/app/documents/policies/code_of_conduct_enforcement.markdown
@@ -45,7 +45,7 @@ Possible responses may include:
 - A private reprimand from the subcommittee to the individual(s) involved. In this case, the subcommittee chair will deliver that reprimand to the individual(s) over email, cc'ing the subcommittee.
 - A public reprimand. In this case, the subcommittee chair will deliver that reprimand in the same venue that the violation occurred (i.e. in Slack for a Slack violation; email for an email violation, etc.). The committee may choose to publish this message elsewhere for posterity.
 - An imposed vacation (i.e. asking someone to "take a week off" from Ruby Down Under or the Ruby AU Slack). The subcommittee chair will communicate this "vacation" to the individual(s). They'll be asked to take this vacation voluntarily, but if they don't agree then a temporary ban may be imposed to enforce this vacation.
-- A permanent or temporary ban from some or all Ruby Australia spaces (Slack, forums, meetups, camps & conferences, etc.). The subcommittee will maintain records of all such bans so that they may be reviewed in the future, extended to new Ruby Australia spaces, or otherwise maintained.
+- A permanent or temporary ban from some or all Ruby Australia spaces (Slack, forums, meetups, retreats & conferences, etc.). The subcommittee will maintain records of all such bans so that they may be reviewed in the future, extended to new Ruby Australia spaces, or otherwise maintained.
 - A request for a public or private apology. The chair will deliver this request. The subcommittee may, if it chooses, attach "strings" to this request: for example, the subcommittee may ask a violator to apologise in order to retain their membership on the Ruby Down Under forum.
 - Expulsion from Ruby Australia and revocation of voting rights.
 

--- a/app/documents/policies/code_of_conduct_reporting.markdown
+++ b/app/documents/policies/code_of_conduct_reporting.markdown
@@ -45,7 +45,7 @@ Once the subcommittee has a complete account of the events they will make a deci
 - A private reprimand from the subcommittee to the individual(s) involved.
 - A public reprimand.
 - An imposed vacation (i.e. asking someone to "take a week off" from Ruby Down Under or the Ruby AU Slack).
-- A permanent or temporary ban from some or all Ruby Australia spaces (Slack, forums, meetups, camps & conferences, etc.).
+- A permanent or temporary ban from some or all Ruby Australia spaces (Slack, forums, meetups, retreats & conferences, etc.).
 - A request for a public or private apology.
 - Revocation of Ruby AU membership, including voting rights.
 

--- a/app/views/admin/imported_members/index.html.erb
+++ b/app/views/admin/imported_members/index.html.erb
@@ -13,7 +13,7 @@
           <div class="space-y-2">
             <div class="flex flex-col">
               <%= label_tag :source, "Source", class: "block text-sm font-medium text-gray-700 mb-1 after:content-['*'] after:ml-0.5 after:text-ruby-red" %>
-              <%= text_field_tag :source, nil, class: "block w-full rounded-md border-gray-300 shadow-sm focus:border-ruby-red focus:ring-ruby-red sm:text-sm py-2", placeholder: "e.g. Rails Camp 25" %>
+              <%= text_field_tag :source, nil, class: "block w-full rounded-md border-gray-300 shadow-sm focus:border-ruby-red focus:ring-ruby-red sm:text-sm py-2", placeholder: "e.g. Ruby Retreat 25" %>
             </div>
             <p class="text-xs text-gray-500 mt-1">
               When we send an email to confirm the membership, we use this text to indicate where the details were sourced from.

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -6,8 +6,8 @@
       <p>
         To meet up with other Rubyists and Ruby-curious folks in person, you could perhaps attend our yearly
         <%= link_to "RubyConf AU", "https://rubyconf.org.au", class: "white-link" %> conference, or our
-        <%= link_to "Rails Camp", "https://rails.camp", class: "white-link" %> social coding weekends, and our more
-        regular meetings for talks and coding across the country.
+        <%= link_to "Ruby Retreat", "https://rails.camp", class: "white-link" %> (formally known as Rails Camp)
+        social coding weekends, and our more regular meetings for talks and coding across the country.
       </p>
 
       <p>

--- a/app/views/invitation_mailer/invite.html.erb
+++ b/app/views/invitation_mailer/invite.html.erb
@@ -9,7 +9,7 @@ Join Ruby Australia.
 <% end %>
 
 <h2>What is Ruby Australia?</h2>
-<p>Ruby Australia is the organisation behind many Ruby-related events across Australia, including Rails Camps, RubyConf AU, RailsGirls, and monthly meets in many cities. We provide financial and logistical support to event organisers, and seek to grow and improve the Ruby community across the country.</p>
+<p>Ruby Australia is the organisation behind many Ruby-related events across Australia, including RubyConf AU, Ruby Retreats, RailsGirls, and monthly meets in many cities. We provide financial and logistical support to event organisers, and seek to grow and improve the Ruby community across the country.</p>
 
 <% if @sources.present? %>
 <h2>Why am I receiving this email?</h2>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,14 +9,14 @@
   <meta name="robots" content="index,follow" />
   <meta name="description" content="Ruby Australia, an organisation that is dedicated to supporting the community and
   events around Australia focused on the Ruby programming language. Providing financial and institutional support for
-  RubyConf AU, Rails Camps, RailsGirls, and the meetups across the country." />
+  RubyConf AU, Ruby Retreats, RailsGirls, and the meetups across the country." />
   <meta name="keywords" content="ruby, rails, australia, melbourne, sydney, canberra, perth, central coast, brisbane, perth,
   western australia, sa, south australia, victoria, new south wales, nsw, vic, qld, queensland, wa, can,
   programming, meetup, group, user group, conferences, events" />
   <meta property="og:title" content="Ruby Australia - <%= yield :heading %>" />
   <meta property="og:description" content="We are an organisation that is dedicated to supporting the community and
   events around Australia focused on the Ruby programming language. Providing financial and institutional support for
-  RubyConf AU, Rails Camps, RailsGirls, and the meetups across the country." />
+  RubyConf AU, Ruby Retreats, RailsGirls, and the meetups across the country." />
   <meta name="view-transition" content="same-origin" />
   <meta name="turbo-refresh-method" content="morph">
   <meta name="turbo-refresh-scroll" content="preserve">

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -34,7 +34,7 @@
       <div class="text-center sm:text-left">
         <h3 class="font-bold text-base sm:text-lg mb-3">Events</h3>
         <ul class="space-y-2">
-          <li><%= link_to "Rails Camp", "https://rails.camp", class: "footer-link" %></li>
+          <li><%= link_to "Ruby Retreat", "https://rails.camp", class: "footer-link" %></li>
           <li><%= link_to "RubyConf AU", "https://rubyconf.org.au", class: "footer-link" %></li>
           <li><%= link_to "Meetups", events_path, class: "footer-link" %></li>
           <li><%= link_to "Rails Girls", "/rails-girls", class: "footer-link" %></li>

--- a/app/views/shared/_section-meetups.html.erb
+++ b/app/views/shared/_section-meetups.html.erb
@@ -2,7 +2,7 @@
   <div class="w-5xl m-auto flex flex-col justify-center">
     <article id="in-person" class="welcome md:ml-10 p-10">
       <h1>Meetups</h1>
-      <p>To meet up with other Rubyists and Ruby-curious folks in person, you could perhaps attend our yearly <%= link_to "RubyConf AU", "https://rubyconf.org.au" %> conference, our twice-yearly <%= link_to "Rails Camp", "https://rails.camp" %> social coding weekends, or our more <a href="#events">regular meetings</a> for talks and coding across the country.</p>
+      <p>To meet up with other Rubyists and Ruby-curious folks in person, you could perhaps attend our yearly <%= link_to "RubyConf AU", "https://rubyconf.org.au" %> conference, our twice-yearly <%= link_to "Ruby Retreats", "https://rails.camp" %> social coding weekends, or our more <a href="#events">regular meetings</a> for talks and coding across the country.</p>
 
       <p>Many cities and regions around Australia have regular meetings, often featuring presentations on a variety of Ruby and industry-related topics, and providing opportunities to socialise with other Rubyists.</p>
 

--- a/app/views/sponsors/index.html.erb
+++ b/app/views/sponsors/index.html.erb
@@ -8,7 +8,7 @@
 
     <p>
       We are very lucky to have many companies who have provided sponsorship over the years to help us achieve these goals,
-      particularly through our <a href="/events" class="white-link">regular events</a>: RubyConf AU, Rails Camp, ongoing city meetups,
+      particularly through our <a href="/events" class="white-link">regular events</a>: RubyConf AU, Ruby Retreat, ongoing city meetups,
       and Rails Girls. Their sponsorship support combined with the massive efforts of our volunteer organisers have created
       world-class conferences and gatherings.
     </p>

--- a/spec/factories/imported_member.rb
+++ b/spec/factories/imported_member.rb
@@ -7,6 +7,6 @@ FactoryBot.define do
       "user#{n}@example.com"
     end
 
-    data { { "sources" => ["Rails Camp"] } }
+    data { { "sources" => ["Ruby Retreat"] } }
   end
 end

--- a/spec/features/committee_imports_members_spec.rb
+++ b/spec/features/committee_imports_members_spec.rb
@@ -21,14 +21,14 @@ RSpec.describe "Committee importing members", type: :feature do
     jules = FactoryBot.create(:user, email: "jules@ruby.test")
     jules.memberships.current.update left_at: 1.minute.ago
 
-    camp = Tempfile.new("camp")
-    camp.write output
-    camp.rewind
+    retreat = Tempfile.new("retreat")
+    retreat.write output
+    retreat.rewind
 
     click_link "Imported Members"
 
-    fill_in "Source", with: "Rails Camp"
-    attach_file "CSV File", camp.path
+    fill_in "Source", with: "Ruby Retreat"
+    attach_file "CSV File", retreat.path
     click_button "Upload"
 
     expect(page).to have_content("Alex")
@@ -37,7 +37,7 @@ RSpec.describe "Committee importing members", type: :feature do
     expect(page).not_to have_content("Jules")
     expect(page).not_to have_content("Lindsay")
 
-    camp.close
+    retreat.close
 
     output = CSV.generate do |csv|
       csv << %w[ticket_full_name ticket_email]


### PR DESCRIPTION
Rails Camps were replaced with Ruby Retreats around 2020 to make them more inclusive and to better reflect the nature of the events. The term "Rails Camp" is now considered outdated in this context.

This PR does not change the name used for mailing lists. That change will require coordination with Campaign Monitor, and will be addressed in a separate PR ([issue #119](https://github.com/rubyaustralia/committee/issues/119))

It also doesn't modify the constitution, which will need to be to run through an official process before being modified