### PR TITLE
Add verification tag for Google Search Console

### DIFF
--- a/sites/melbourne/app/views/layouts/melbourne/application.html.erb
+++ b/sites/melbourne/app/views/layouts/melbourne/application.html.erb
@@ -5,13 +5,14 @@
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <%= display_meta_tags site: "Ruby Melbourne" %>
+  <%# Google Search Console verification %><meta name="google-site-verification" content="6vzGW_YJ2E2E0np4kIN-mkHqU-BOnuvaeLaA5UnD3ns" />
 
   <%= yield :head %>
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Lekton:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-  
+
   <!-- Preload critical LCP image for fastest paint -->
   <link rel="preload" as="image" href="<%= vite_asset_path('images/melbourne/bg-wall-optimized.webp') %>" type="image/webp">
   <link rel="preload" as="image" href="<%= vite_asset_path('images/melbourne/bg-wall-optimized.jpg') %>" type="image/jpeg">


### PR DESCRIPTION
Relates to #343

We would like to administrate the searchability of melbourne.ruby.org.au via the Google Search Console. There are multiple ways to verify ownership of a domain, but using a meta tag doesn't require working with someone with DNS access; it can be handled entirely by the people managing our meetup sites.

The tag that has been added authorizes melbourne@ruby.org.au to administrate melbourne.ruby.org.au via the [Google Search Console](https://search.google.com/search-console/). It will need to remain in the HTML even after verification