### PR TITLE
Migrate to fork of devise-multi_email

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'bugsnag'
 gem 'createsend'
 gem 'decent_exposure'
 gem 'devise'
-gem 'devise-multi_email'
+gem 'devise-multi_email', github: 'rubyaustralia/devise-multi_email', branch: 'main'
 gem 'friendly_id', '~> 5.5.0'
 gem 'icalendar'
 gem "image_processing", "~> 1.13"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/rubyaustralia/devise-multi_email.git
+  revision: 8af332653e087cbbb6b6a411a1bda34bb54e167a
+  branch: main
+  specs:
+    devise-multi_email (3.0.1)
+      devise
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -138,8 +146,6 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
-    devise-multi_email (3.0.1)
-      devise
     diff-lcs (1.6.2)
     docile (1.4.1)
     drb (2.2.3)
@@ -567,7 +573,7 @@ DEPENDENCIES
   debug
   decent_exposure
   devise
-  devise-multi_email
+  devise-multi_email!
   factory_bot_rails
   faker
   friendly_id (~> 5.5.0)


### PR DESCRIPTION
devise-multi_email is throwing warnings that the method `Devise.activerecord51?` has been deprecated and will be removed in the next major version of Devise.

Unfortunately, the gem hasn't been updated in over 3 years, so it has been forked under `rubyaustralia`