### PR TITLE
Makes anchor elements distinguishable from text in post content

### DIFF
--- a/app/frontend/stylesheets/actiontext.css
+++ b/app/frontend/stylesheets/actiontext.css
@@ -438,3 +438,15 @@ trix-editor .attachment__metadata {
   padding: 0 !important;
   max-width: 100% !important;
 }
+
+/*
+ * Extends trix.css's link styles to match the .white-link class.
+*/
+.trix-content a {
+  color: #D30001; /* --color-ruby-red */
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.trix-content a:not(:hover, :focus) {
+  text-decoration-color: color-mix(in srgb, currentColor, transparent 75%);
+}


### PR DESCRIPTION
> Description copied from https://github.com/rubyaustralia/ruby_au/issues/340#issuecomment-3201014801

I'm far from fluent in CSS so take what I've found with a grain of salt.

The `application.scss` stylesheet has a class called `white-link`, a class for links on white backgrounds. It looks like the right kind style to use in this case (links embedded in a posts content).

The `actiontext.css` stylesheet contains default styles for [Trix](https://github.com/basecamp/trix) as well as some overrides. Another override could be added just for links inside Trix content. Applying the `white-link` class directly in the stylesheet might not be possible though. If that's the case, we could duplicate the styles instead :hurtrealbad:

I copied the `white-link` styles, translated tailwind into vanilla CSS, then added it to the bottom of `actiontext.css` and it works. Not sure if it's right way to do it though :)