### PR TITLE
Fix timezone issues in ICS event creation

### DIFF
--- a/app/lib/campaigns/event.rb
+++ b/app/lib/campaigns/event.rb
@@ -31,8 +31,9 @@ class Campaigns::Event
 
   def add_event
     calendar.event do |event|
-      event.dtstart = datetime(rsvp_event.happens_at)
-      event.dtend = datetime(rsvp_event.happens_at + 90.minutes)
+      happens_at = rsvp_event.happens_at.utc
+      event.dtstart = datetime(happens_at)
+      event.dtend = datetime(happens_at + 90.minutes)
       event.summary = title
       event.description = rsvp_event.link
 

--- a/spec/lib/campaigns/event_spec.rb
+++ b/spec/lib/campaigns/event_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe Campaigns::Event do
+  describe ".call" do
+    let(:rsvp_event) { build_stubbed(:rsvp_event) }
+
+    it "initializes the class and calls #call" do
+      event = described_class.new(rsvp_event)
+      allow(described_class).to receive(:new).and_return(event)
+      allow(event).to receive(:call)
+
+      described_class.call(rsvp_event)
+
+      expect(described_class).to have_received(:new).with(rsvp_event)
+      expect(event).to have_received(:call)
+    end
+  end
+
+  describe "#call" do
+    subject(:ics) { described_class.new(rsvp_event).call }
+
+    let(:rsvp_event) { create(:rsvp_event, title: "AGM", happens_at:, link: "https://example.com") }
+    let(:happens_at) { Time.find_zone(time_zone).parse("2025-01-01 11:00:00") }
+    let(:time_zone) { "UTC" }
+
+    it "returns an ICS file describing the event" do
+      expect(ics).to include(
+        %w[
+          BEGIN:VTIMEZONE
+          TZID:UTC
+          END:VTIMEZONE
+        ].join("\r\n")
+      )
+      expect(ics).to include(
+        [
+          "DTSTART:20250101T110000Z",
+          "DTEND:20250101T123000Z",
+          "DESCRIPTION:https://example.com",
+          "SUMMARY:Ruby Australia AGM"
+        ].join("\r\n")
+      )
+    end
+
+    context "when the event is not scheduled in UTC time" do
+      let(:time_zone) { "Melbourne" }
+
+      it "returns an ICS file describing the event" do
+        expect(ics).to include(
+          %w[
+            BEGIN:VTIMEZONE
+            TZID:UTC
+            END:VTIMEZONE
+          ].join("\r\n")
+        )
+        expect(ics).to include(
+          [
+            "DTSTART:20250101T000000Z",
+            "DTEND:20250101T013000Z",
+            "DESCRIPTION:https://example.com",
+            "SUMMARY:Ruby Australia AGM"
+          ].join("\r\n")
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
The timezone of this application has been set to "Australia/Melbourne", but the ICS events assume UTC time. This means that the events were being scheduled either 10 or 11 hours later than expected if the event was scheduled in Melbourne time