### PR TITLE
Update mailing list from Rails Camp to Ruby Retreat

### DIFF
--- a/app/lib/mailing_list.rb
+++ b/app/lib/mailing_list.rb
@@ -2,7 +2,7 @@
 
 class MailingList
   LISTS = [
-    "Rails Camp",
+    "Ruby Retreat",
     "RubyConf AU",
     "RailsGirls"
   ].freeze

--- a/spec/features/user_confirms_email_spec.rb
+++ b/spec/features/user_confirms_email_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.feature "User confirms account", type: :feature do
   let(:user) do
-    create :user, confirmed_at: nil, mailing_lists: { "Rails Camp" => "true" }
+    create :user, confirmed_at: nil, mailing_lists: { "Ruby Retreat" => "true" }
   end
 
   before do
@@ -50,7 +50,7 @@ RSpec.feature "User confirms account", type: :feature do
     user.reload
     expect(user).to be_confirmed
     expect(user.memberships.current.count).to eq(1)
-    expect(user.mailing_lists["Rails Camp"]).to eq("true")
+    expect(user.mailing_lists["Ruby Retreat"]).to eq("true")
     expect(user.mailing_lists["RubyConf AU"]).to eq("false")
     expect(user.mailing_lists["RailsGirls"]).to eq("false")
 

--- a/spec/features/visitor_signs_up_spec.rb
+++ b/spec/features/visitor_signs_up_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature "Visitor signs up", type: :feature do
     fill_in "Full Name", with: 'Jane Doe'
     fill_in "Postal Address", with: '1 High Street'
 
-    check "Rails Camp"
+    check "Ruby Retreat"
 
     fill_in "Ruby?", with: "Random bot generated string"
 
@@ -61,7 +61,7 @@ RSpec.feature "Visitor signs up", type: :feature do
     fill_in "Full Name", with: 'Jane Doe'
     fill_in "Postal Address", with: '1 High Street'
 
-    check "Rails Camp"
+    check "Ruby Retreat"
 
     fill_in "Ruby?", with: "Ruby"
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -23,7 +23,7 @@ end
 
 ENV["RUBYCONF_AU_LIST_ID"] ||= "conf-key"
 ENV["RAILSGIRLS_LIST_ID"]  ||= "girls-key"
-ENV["RAILS_CAMP_LIST_ID"]  ||= "camp-key"
+ENV["RUBY_RETREAT_LIST_ID"] ||= "camp-key"
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures


### PR DESCRIPTION
Rails Camps were replaced with Ruby Retreats in around 2020 to make them more inclusive and to better reflect the nature of the events. The term "Rails Camp" is now considered outdated in this context

Most of the copy on the site has already been changed, but the mailing list was coordinated with changes in Campaign Monitor

**Note:** A new secret, `RUBY_RETREAT_LIST_ID`, has been added to Heroku, and the existing one, `RAILS_CAMP_LIST_ID`, will be removed after deployment