### PR TITLE
🆙 Update Bluethumb url

### DIFF
--- a/config/data/sponsors.yml
+++ b/config/data/sponsors.yml
@@ -9,7 +9,7 @@
 
 - name: Bluethumb
   key: bluethumb
-  url: https://bluethumb.com.au/
+  url: https://tech.bluet.hm/
   images:
     - 2024/bluethumb-500x109.png
   tier: Opal


### PR DESCRIPTION
Bluethumb is one of our Sponsors. They reached out to sponsorship@ruby.org.au and requested that their target link be updated. 