### PR TITLE
366 user management in admin not allowing deletion

### DIFF
--- a/app/controllers/admin/user_management_controller.rb
+++ b/app/controllers/admin/user_management_controller.rb
@@ -34,17 +34,14 @@ class Admin::UserManagementController < Admin::ApplicationController
   private
 
   def respond_with_action_result(result, success_action)
-    if result[:success]
-      respond_with_result(result, success_action)
-    else
-      message_type = 'error'
+    return respond_with_result(result, success_action) if result[:success]
 
-      respond_to do |format|
-        format.turbo_stream do
-          render turbo_stream: notification_stream(result[:message], message_type)
-        end
-        format.html { redirect_with_flash(result[:message], message_type) }
+    message_type = 'error'
+    respond_to do |format|
+      format.turbo_stream do
+        render turbo_stream: notification_stream(result[:message], message_type)
       end
+      format.html { redirect_with_flash(result[:message], message_type) }
     end
   end
 

--- a/app/controllers/admin/user_management_controller.rb
+++ b/app/controllers/admin/user_management_controller.rb
@@ -37,7 +37,14 @@ class Admin::UserManagementController < Admin::ApplicationController
     if result[:success]
       respond_with_result(result, success_action)
     else
-      respond_with_result(result, :show_error)
+      message_type = 'error'
+
+      respond_to do |format|
+        format.turbo_stream do
+          render turbo_stream: notification_stream(result[:message], message_type)
+        end
+        format.html { redirect_with_flash(result[:message], message_type) }
+      end
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   before_action :configure_permitted_parameters, if: :devise_controller?
-  before_action :track_ahoy_visit
+  before_action :track_ahoy_visit, unless: -> { Rails.env.development? }
 
   protected
 

--- a/app/frontend/controllers/user_management_controller.js
+++ b/app/frontend/controllers/user_management_controller.js
@@ -37,6 +37,20 @@ export default class extends Controller {
     }
   }
 
+  confirmUserForceDelete(event) {
+    event.preventDefault()
+    event.stopPropagation()
+
+    if (event.target.dataset.processing === "true") return
+
+    const userName = event.target.dataset.userManagementUserNameParam
+
+    if (confirm(`⚠️  FORCE DELETE WARNING ⚠️\n\nThis will permanently delete ${userName} and ALL associated records including:\n- Posts they've authored\n- Email records\n- Membership history\n- RSVPs\n- Access requests\n\nThis action CANNOT be undone!\n\nAre you absolutely sure you want to proceed?`)) {
+      event.target.dataset.processing = "true"
+      event.target.closest('form').submit()
+    }
+  }
+
   confirmUserDeactivate(event) {
     event.preventDefault()
     event.stopPropagation()

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -53,7 +53,7 @@ class User < ApplicationRecord
 
   has_many :memberships, dependent: :destroy
   has_many :emails, dependent: :destroy
-  has_many :access_requests, foreign_key: :recorder_id, dependent: :destroy
+  has_many :access_requests, foreign_key: :recorder_id, dependent: :destroy, inverse_of: :recorder
 
   scope :seeking_work, -> { where(seeking_work: true).where.not(linkedin_url: [nil, ""]) }
   scope :unconfirmed, -> { where(confirmed_at: nil) }
@@ -110,7 +110,6 @@ class User < ApplicationRecord
       logger.error "Failed to update email for user #{id}: #{new_email.errors.full_messages.join(', ')}"
     end
   end
-
 
   def update_mailing_list_and_memberships(email_update: false)
     subscribe_to_lists

--- a/app/services/dashboard_data_service.rb
+++ b/app/services/dashboard_data_service.rb
@@ -29,15 +29,15 @@ class DashboardDataService
   end
 
   def never_logged_in_members
-    User.where(last_sign_in_at: nil)
+    User.includes(:emails).where(last_sign_in_at: nil)
   end
 
   def recently_updated_members
-    User.order(updated_at: :desc).limit(5)
+    User.includes(:emails).order(updated_at: :desc).limit(5)
   end
 
   def recently_logged_in_members
-    User.where.not(last_sign_in_at: nil).order(last_sign_in_at: :desc).limit(5)
+    User.includes(:emails).where.not(last_sign_in_at: nil).order(last_sign_in_at: :desc).limit(5)
   end
 
   def recent_posts

--- a/app/services/user_association_remover.rb
+++ b/app/services/user_association_remover.rb
@@ -27,9 +27,11 @@ class UserAssociationRemover
   end
 
   def remove_membership_campaign_deliveries(membership)
-    return unless membership.respond_to?(:campaign_deliveries)
+    return unless defined?(CampaignDelivery)
 
-    membership.campaign_deliveries.destroy_all
+    CampaignDelivery.where(membership_id: membership.id).destroy_all
+  rescue NameError
+    # CampaignDelivery class doesn't exist, skip
   end
 
   def remove_memberships
@@ -37,7 +39,7 @@ class UserAssociationRemover
   end
 
   def remove_extra_emails
-    user.emails.where.not(id: user.email_id).destroy_all
+    user.emails.destroy_all
   end
 
   def remove_access_requests
@@ -49,8 +51,8 @@ class UserAssociationRemover
   def nullify_authored_posts
     return unless defined?(Post)
 
-    Post.where(author: user).find_each do |post|
-      post.update!(author_id: nil)
-    end
+    Rails.logger.info "Removing posts for user #{user.id}"
+    Post.where(user_id: user.id).destroy_all
+    Rails.logger.info "Completed posts removal for user #{user.id}"
   end
 end

--- a/app/services/user_management/base_service.rb
+++ b/app/services/user_management/base_service.rb
@@ -1,0 +1,22 @@
+class UserManagement::BaseService
+  def initialize(user, current_user)
+    @user = user
+    @current_user = current_user
+  end
+
+  def can_modify_user?
+    user != current_user
+  end
+
+  private
+
+  attr_reader :user, :current_user
+
+  def success_result(message)
+    { success: true, message: message }
+  end
+
+  def failure_result(message)
+    { success: false, message: message }
+  end
+end

--- a/app/services/user_management/deletion_service.rb
+++ b/app/services/user_management/deletion_service.rb
@@ -1,0 +1,50 @@
+class UserManagement::DeletionService < UserManagement::BaseService
+  def delete_user
+    return failure_result('You cannot delete your own account') unless can_modify_user?
+
+    dependencies = UserDependencyChecker.new(user).check_dependencies
+    return dependency_error(dependencies) if dependencies.any?
+
+    user.destroy!
+    success_result("#{user.full_name} has been deleted successfully")
+  rescue ActiveRecord::InvalidForeignKey => e
+    table_name = extract_table_from_error(e.message)
+    failure_result("Cannot delete #{user.full_name} - user has associated records in #{table_name}. Please contact a developer to resolve this.")
+  rescue StandardError
+    failure_result('Failed to delete user due to an unexpected error')
+  end
+
+  def force_delete_user
+    return failure_result('You cannot delete your own account') unless can_modify_user?
+
+    perform_force_delete
+    success_result("#{user.full_name} and all associated records have been force deleted")
+  rescue StandardError => e
+    log_force_delete_error(e)
+    failure_result("Failed to force delete user: #{e.message}")
+  end
+
+  private
+
+  def perform_force_delete
+    ActiveRecord::Base.transaction do
+      UserAssociationRemover.new(user).remove_all
+      user.destroy!
+    end
+  end
+
+  def log_force_delete_error(error)
+    Rails.logger.error "Force delete failed for user #{user.id}: #{error.message}"
+    Rails.logger.error error.backtrace.join("\n")
+  end
+
+  def dependency_error(dependencies)
+    message = "Cannot delete #{user.full_name} - user has associated records: #{dependencies.join(', ')}. Consider deactivating the membership instead."
+    failure_result(message)
+  end
+
+  def extract_table_from_error(error_message)
+    match = error_message.match(/table "([^"]+)"/)
+    match ? match[1] : "unknown table"
+  end
+end

--- a/app/services/user_management/membership_service.rb
+++ b/app/services/user_management/membership_service.rb
@@ -1,0 +1,36 @@
+class UserManagement::MembershipService < UserManagement::BaseService
+  def deactivate_user
+    return failure_result('You cannot deactivate your own account') unless can_modify_user?
+
+    current_memberships = user.memberships.where(left_at: nil)
+    current_memberships.each { |membership| membership.update!(left_at: Time.current) }
+
+    success_result("#{user.full_name}'s membership has been deactivated")
+  rescue StandardError
+    failure_result('Failed to deactivate user membership')
+  end
+
+  def remove_all
+    log_removal_start
+    remove_membership_associations
+    remove_memberships
+    remove_extra_emails
+    remove_access_requests
+    nullify_authored_posts
+    log_removal_completion
+  end
+
+  private
+
+  def log_removal_start
+    Rails.logger.info "Starting removal of associations for user #{user.id}"
+  end
+
+  def log_removal_completion
+    Rails.logger.info "Completed membership associations removal"
+    Rails.logger.info "Completed memberships removal"
+    Rails.logger.info "Completed emails removal"
+    Rails.logger.info "Completed access requests removal"
+    Rails.logger.info "Completed posts handling"
+  end
+end

--- a/app/services/user_management/role_service.rb
+++ b/app/services/user_management/role_service.rb
@@ -1,0 +1,33 @@
+class UserManagement::RoleService < UserManagement::BaseService
+  def update_role(committee_status)
+    return handle_successful_role_update if perform_role_update(committee_status)
+
+    log_role_update_failure
+    failure_result('Failed to update user role')
+  rescue StandardError => e
+    log_role_update_exception(e)
+    failure_result("Failed to update user role: #{e.message}")
+  end
+
+  private
+
+  def perform_role_update(committee_status)
+    user.update!(committee: committee_status)
+    true
+  rescue StandardError
+    false
+  end
+
+  def handle_successful_role_update
+    success_result("#{user.full_name || user.email || 'User'}'s role updated successfully")
+  end
+
+  def log_role_update_failure
+    Rails.logger.error "Failed to update user role for user #{user.id}"
+  end
+
+  def log_role_update_exception(exception)
+    Rails.logger.error "Exception in update_role for user #{user.id}: #{exception.message}"
+    Rails.logger.error exception.backtrace.join("\n")
+  end
+end

--- a/app/services/user_management_service.rb
+++ b/app/services/user_management_service.rb
@@ -4,102 +4,31 @@ class UserManagementService
     @current_user = current_user
   end
 
-  def can_modify_user?
-    user != current_user
-  end
+  delegate :can_modify_user?, to: :deletion_service
 
-  def delete_user
-    return failure_result('You cannot delete your own account') unless can_modify_user?
+  delegate :delete_user, to: :deletion_service
 
-    dependencies = UserDependencyChecker.new(user).check_dependencies
-    return dependency_error(dependencies) if dependencies.any?
+  delegate :force_delete_user, to: :deletion_service
 
-    user.destroy!
-    success_result("#{user.full_name} has been deleted successfully")
-  rescue ActiveRecord::InvalidForeignKey => e
-    table_name = extract_table_from_error(e.message)
-    failure_result("Cannot delete #{user.full_name} - user has associated records in #{table_name}. Please contact a developer to resolve this.")
-  rescue StandardError
-    failure_result('Failed to delete user due to an unexpected error')
-  end
+  delegate :deactivate_user, to: :membership_service
 
-  def force_delete_user
-    return failure_result('You cannot delete your own account') unless can_modify_user?
+  delegate :update_role, to: :role_service
 
-    ActiveRecord::Base.transaction do
-      UserAssociationRemover.new(user).remove_all
-      user.destroy!
-    end
-
-    success_result("#{user.full_name} and all associated records have been force deleted")
-  rescue StandardError => e
-    Rails.logger.error "Force delete failed for user #{user.id}: #{e.message}"
-    Rails.logger.error e.backtrace.join("\n")
-    failure_result("Failed to force delete user: #{e.message}")
-  end
-
-  def remove_all
-    Rails.logger.info "Starting removal of associations for user #{user.id}"
-
-    remove_membership_associations
-    Rails.logger.info "Completed membership associations removal"
-
-    remove_memberships
-    Rails.logger.info "Completed memberships removal"
-
-    remove_extra_emails
-    Rails.logger.info "Completed emails removal"
-
-    remove_access_requests
-    Rails.logger.info "Completed access requests removal"
-
-    nullify_authored_posts
-    Rails.logger.info "Completed posts handling"
-  end
-
-  def deactivate_user
-    return failure_result('You cannot deactivate your own account') unless can_modify_user?
-
-    current_memberships = user.memberships.where(left_at: nil)
-    current_memberships.each { |membership| membership.update!(left_at: Time.current) }
-
-    success_result("#{user.full_name}'s membership has been deactivated")
-  rescue StandardError
-    failure_result('Failed to deactivate user membership')
-  end
-
-  def update_role(committee_status)
-    if user.update_column(:committee, committee_status)
-      success_result("#{user.full_name || user.email || 'User'}'s role updated successfully")
-    else
-      Rails.logger.error "Failed to update user role for user #{user.id}"
-      failure_result('Failed to update user role')
-    end
-  rescue StandardError => e
-    Rails.logger.error "Exception in update_role for user #{user.id}: #{e.message}"
-    Rails.logger.error e.backtrace.join("\n")
-    failure_result("Failed to update user role: #{e.message}")
-  end
+  delegate :remove_all, to: :membership_service
 
   private
 
   attr_reader :user, :current_user
 
-  def dependency_error(dependencies)
-    message = "Cannot delete #{user.full_name} - user has associated records: #{dependencies.join(', ')}. Consider deactivating the membership instead."
-    failure_result(message)
+  def deletion_service
+    @deletion_service ||= UserManagement::DeletionService.new(user, current_user)
   end
 
-  def success_result(message)
-    { success: true, message: message }
+  def role_service
+    @role_service ||= UserManagement::RoleService.new(user, current_user)
   end
 
-  def failure_result(message)
-    { success: false, message: message }
-  end
-
-  def extract_table_from_error(error_message)
-    match = error_message.match(/table "([^"]+)"/)
-    match ? match[1] : "unknown table"
+  def membership_service
+    @membership_service ||= UserManagement::MembershipService.new(user, current_user)
   end
 end

--- a/app/views/admin/dashboards/_user_row.html.erb
+++ b/app/views/admin/dashboards/_user_row.html.erb
@@ -6,8 +6,10 @@
     <% end %>
   </td>
   <td class="px-4 py-4 whitespace-nowrap text-sm text-gray-900">
-    <%= user.email %>
+    <%= user.primary_email || "No email found" %>
+    <!-- Debug: <%= user.emails.count %> emails, primary: <%= user.emails.find_by(primary: true)&.email.inspect %>, fallback: <%= user.email.inspect %> -->
   </td>
+
   <td class="px-4 py-4 whitespace-nowrap">
     <div class="flex flex-col space-y-1">
       <span class="inline-flex px-2 py-1 text-xs font-semibold rounded-full <%= user.committee? ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-800' %>">
@@ -68,7 +70,17 @@
                         user_management_user_name_param: user.full_name
                       },
                       form: { data: { turbo_frame: "user_search_results" } } %>
-      <% end %>
+
+        <%= button_to "Force Delete", admin_force_delete_user_path,
+                      params: { user_id: user.id },
+                      method: :delete,
+                      class: "text-red-800 hover:text-red-950 text-xs bg-transparent border-0 p-0 ml-2",
+                      data: {
+                        action: "click->user-management#confirmUserForceDelete",
+                        user_management_user_name_param: user.full_name
+                      },
+                      form: { data: { turbo_frame: "user_search_results" } } %>
+    <% end %>
     </div>
   </td>
 </tr>

--- a/app/views/admin/dashboards/show.html.erb
+++ b/app/views/admin/dashboards/show.html.erb
@@ -101,7 +101,9 @@
       <ul class="divide-y">
         <% @recently_updated_members.each do |member| %>
           <li class="py-2">
-            <%= member.email %>
+            <%= link_to member.full_name.present? ? member.full_name : member.email,
+                        "mailto:#{member.email}",
+                        class: "text-blue-600 hover:underline" %>
             <span class="text-gray-500 text-sm block">
               Updated <%= time_ago_in_words(member.updated_at) %> ago
             </span>
@@ -115,7 +117,9 @@
       <ul class="divide-y">
         <% @recently_logged_in_members.each do |member| %>
           <li class="py-2">
-            <%= member.email %>
+            <%= link_to member.full_name.present? ? member.full_name : member.email,
+                        "mailto:#{member.email}",
+                        class: "text-blue-600 hover:underline" %>
             <span class="text-gray-500 text-sm block">
               Logged in <%= time_ago_in_words(member.last_sign_in_at) %> ago
             </span>

--- a/db/migrate/20250922132138_migrate_user_emails_to_emails_table.rb
+++ b/db/migrate/20250922132138_migrate_user_emails_to_emails_table.rb
@@ -1,0 +1,8 @@
+class MigrateUserEmailsToEmailsTable < ActiveRecord::Migration[8.0]
+  def up
+    User.find_each do |user|
+      user.update_emails
+    end
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_14_123836) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_22_132138) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 


### PR DESCRIPTION
- Spam accounts can now be deleted by admin
- Devise multi email is now set up to migrate user emails to emails table

Resolves [#366]