### PR TITLE
Melbourne: Add remaining 2025 meetups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 # Ignore system specific files
 .DS_Store
 
+# Ignore IRB history file
+.irb_history
+
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Ignore bundler config.
 /.bundle
 
+# Ignore system specific files
+.DS_Store
+
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*

--- a/.gitignore
+++ b/.gitignore
@@ -19,9 +19,6 @@
 !/log/.keep
 !/tmp/.keep
 
-# Ignore Byebug command history file.
-.byebug_history
-
 # Ignore code coverage reports
 /coverage/
 

--- a/sites/melbourne/app/controllers/melbourne/home_controller.rb
+++ b/sites/melbourne/app/controllers/melbourne/home_controller.rb
@@ -3,7 +3,7 @@
 module Melbourne
   class HomeController < ApplicationController
     def show
-      @next_event = Event.next_event
+      @next_event = Event.upcoming(1).first
       @past_events = Event.past(4)
     end
   end

--- a/sites/melbourne/app/controllers/melbourne/home_controller.rb
+++ b/sites/melbourne/app/controllers/melbourne/home_controller.rb
@@ -4,13 +4,7 @@ module Melbourne
   class HomeController < ApplicationController
     def show
       @next_event = Event.next_event
-      @past_events = Event.last(4)
-
-      if @next_event&.in?(@past_events)
-        @past_events.shift
-      else
-        @past_events.pop
-      end
+      @past_events = Event.past(4)
     end
   end
 end

--- a/sites/melbourne/app/models/melbourne/event.rb
+++ b/sites/melbourne/app/models/melbourne/event.rb
@@ -39,8 +39,11 @@ module Melbourne
     end
 
     def self.next_event
-      next_event = all.last
-      next_event if next_event.today_or_in_the_future?
+      all.sort_by(&:date).find(&:today_or_in_the_future?)
+    end
+
+    def self.past(amount = nil)
+      all.sort_by(&:date).reject(&:today_or_in_the_future?).reverse.slice(0..amount&.-(1))
     end
 
     def self.last(amount = 1)

--- a/sites/melbourne/app/models/melbourne/event.rb
+++ b/sites/melbourne/app/models/melbourne/event.rb
@@ -38,12 +38,12 @@ module Melbourne
       all.find { it.slug == slug }
     end
 
-    def self.next_event
-      all.sort_by(&:date).find(&:today_or_in_the_future?)
+    def self.upcoming(amount = nil)
+      all.select(&:today_or_in_the_future?).slice(0..amount&.-(1))
     end
 
     def self.past(amount = nil)
-      all.sort_by(&:date).reject(&:today_or_in_the_future?).reverse.slice(0..amount&.-(1))
+      all.reject(&:today_or_in_the_future?).reverse.slice(0..amount&.-(1))
     end
 
     def self.last(amount = 1)

--- a/sites/melbourne/app/models/melbourne/event.rb
+++ b/sites/melbourne/app/models/melbourne/event.rb
@@ -22,7 +22,6 @@ module Melbourne
     validates :slug, presence: true
     validates :type, presence: true
     validates :venue, presence: true
-    validates :talks, presence: true
 
     def self.all
       @all ||= events_from_yaml_db.map do |event_data|

--- a/sites/melbourne/app/views/melbourne/events/show.html.erb
+++ b/sites/melbourne/app/views/melbourne/events/show.html.erb
@@ -60,12 +60,14 @@
       <p class="text-lg text-black"><%= @event_presenter.description %></p>
     </div>
 
-    <div>
-      <h4 class="pb-1 mb-1 text-gray-500 border-b border-gray-200">Talks</h4>
-      <div class="flex flex-col gap-8 py-4">
-        <%= render collection: @event_presenter.talks, partial: "melbourne/events/talk" %>
+    <% if @event_presenter.talks.any? %>
+      <div>
+        <h4 class="pb-1 mb-1 text-gray-500 border-b border-gray-200">Talks</h4>
+        <div class="flex flex-col gap-8 py-4">
+          <%= render collection: @event_presenter.talks, partial: "melbourne/events/talk" %>
+        </div>
       </div>
-    </div>
+    <% end %>
   </div>
 </article>
 

--- a/sites/melbourne/db/data/events.yml
+++ b/sites/melbourne/db/data/events.yml
@@ -1,4 +1,104 @@
 ---
+- uuid: 177e758b-899b-44ef-be97-9ae4a6841f80
+  date: '2025-11-27'
+  name: 'Ruby Melbourne: November 2025'
+  description: >-
+    Join us at Ruby Melbourne: November 2025
+  slug: 2025-11-27-ruby-melbourne
+  registration_link: https://www.meetup.com/ruby-on-rails-oceania-melbourne/events/305601924/
+  type: meetup
+  venue:
+    name: Ferocia
+    google_maps_url: https://maps.app.goo.gl/9xvvwpdw9BkByKqy9
+    address:
+      street: Level 7/271 Collins St
+      locality: Melbourne
+      postal_code: '3000'
+      region: VIC
+      country: AU
+
+- uuid: 77e5981c-3758-47e8-b65e-f730dbb1df36
+  date: '2025-10-30'
+  name: 'Ruby Melbourne: October 2025'
+  description: >-
+    Join us at Ruby Melbourne: October 2025
+  slug: 2025-10-30-ruby-melbourne
+  registration_link: https://www.meetup.com/ruby-on-rails-oceania-melbourne/events/305601923/
+  type: meetup
+  venue:
+    name: Ferocia
+    google_maps_url: https://maps.app.goo.gl/9xvvwpdw9BkByKqy9
+    address:
+      street: Level 7/271 Collins St
+      locality: Melbourne
+      postal_code: '3000'
+      region: VIC
+      country: AU
+
+- uuid: 48ebf8db-0fc4-4be0-b613-e6b9c03407ab
+  date: '2025-09-25'
+  name: 'Ruby Melbourne: September 2025'
+  description: >-
+    Join us at Ruby Melbourne: September 2025
+  slug: 2025-09-25-ruby-melbourne
+  registration_link: https://www.meetup.com/ruby-on-rails-oceania-melbourne/events/305601922/
+  type: meetup
+  venue:
+    name: Ferocia
+    google_maps_url: https://maps.app.goo.gl/9xvvwpdw9BkByKqy9
+    address:
+      street: Level 7/271 Collins St
+      locality: Melbourne
+      postal_code: '3000'
+      region: VIC
+      country: AU
+  talks:
+    - uuid: f7538e2b-65ba-4d73-8ffa-7884b9a7695d
+      title: 'How trustworthy is Rspec? How I Fell into an RSpec Pitfall'
+      description: |-
+        <p>
+          An interactive demo showing how RSpec silently ignore tests, and how it was found and
+          fixed.
+        </p>
+        <p>
+          I have written a
+          <a href="https://medium.com/@zztczcx/how-i-fell-into-an-rspec-pitfall-and-failed-the-interview-56a7d57ff631">
+            story about it
+          </a>
+          but want to show it with an example.
+        </p>
+      video_url: TBC
+      speakers:
+        - name: Chenxu Zhao
+          contact_details:
+            github_username:
+            x_handle:
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle:
+            website:
+    - uuid: 1617a702-dc4d-4129-8015-f45c4516fb36
+      title: Scaling Databases at Buildkite
+      description: |-
+        <p>
+          From a single DB to replicas to sharding &mdash; how Buildkite scaled Rails + Postgres to
+          support giants like Uber, Shopify, and Slack.
+        </p>
+        <p>
+          Let's talk systems, stability, and the traps we all fall into. Join us for code,
+          community, and some top-tier chats.
+        </p>
+      video_url: TBC
+      speakers:
+        - name: David Barrell
+          contact_details:
+            github_username:
+            x_handle:
+            linkedin_handle:
+            bluesky_handle:
+            mastodon_handle:
+            website:
+
 - uuid: 2509d2e4-58fc-4e1a-b099-6ec1c26dabc2
   date: '2025-08-28'
   name: 'Ruby Melbourne: August 2025'

--- a/sites/melbourne/spec/models/melbourne/event_spec.rb
+++ b/sites/melbourne/spec/models/melbourne/event_spec.rb
@@ -147,6 +147,7 @@ RSpec.describe Melbourne::Event do
       allow(described_class).to \
         receive(:all).and_return(
           [
+            described_class.new(date: 2.days.from_now),
             described_class.new(date: 1.day.ago),
             described_class.new(date: 1.day.from_now)
           ]
@@ -167,6 +168,60 @@ RSpec.describe Melbourne::Event do
         )
 
       expect(described_class.next_event).to be_nil
+    end
+  end
+
+  describe ".past" do
+    it "returns all events that were scheduled to start prior to the current day" do
+      expected_events = [
+        described_class.new(date: 1.year.ago),
+        described_class.new(date: 1.week.ago),
+        described_class.new(date: 1.day.ago)
+      ]
+
+      allow(described_class).to \
+        receive(:all).and_return(
+          expected_events + [
+            described_class.new(date: Time.zone.today),
+            described_class.new(date: 1.day.from_now)
+          ]
+        )
+
+      expect(described_class.past).to match_array(expected_events)
+    end
+
+    context "when it is called with an amount" do
+      it "returns that many past events" do
+        expected_events = [
+          described_class.new(date: 1.week.ago),
+          described_class.new(date: 1.day.ago)
+        ]
+
+        allow(described_class).to \
+          receive(:all).and_return(
+            expected_events + [
+              described_class.new(date: 1.year.ago),
+              described_class.new(date: Time.zone.today),
+              described_class.new(date: 1.day.from_now)
+            ]
+          )
+
+        expect(described_class.past(2)).to eq(expected_events)
+      end
+    end
+
+    context "when there are no past events" do
+      it "returns an empty array" do
+        allow(described_class).to \
+          receive(:all).and_return(
+            [
+              described_class.new(date: Time.zone.today),
+              described_class.new(date: 1.day.from_now)
+            ]
+          )
+
+        expect(described_class.past).to eq([])
+      end
     end
   end
 


### PR DESCRIPTION
We have had members looking for future events. When adding the September, October, and November, I noticed that the site assumed the next event is the last one in the YAML file, and the past events are the 4 events before the last.

This PR searches the events to identify the next and previous events based upon the event date, and added the remaining events to the YAML file