### PR TITLE
Add page showing Ruby Australia roles in plain text

### DIFF
--- a/app/documents/committee_roles.markdown
+++ b/app/documents/committee_roles.markdown
@@ -1,0 +1,45 @@
+# Committee Roles
+
+## President
+
+* The President guides the overall direction of the organisation. They make the final call on major decisions and delegate work to general members. They are in charge of making sure the committee is running smoothly and members are meeting their obligations.
+
+
+## Secretary
+
+* The Secretary has the primary responsibility of keeping organisational records and ensuring formal governance rules for incorporated associations are followed.
+
+
+## Sponsorship Customer Management
+
+* Maintaining relationships with all existing sponsors and ensuring invoices are issues and paid
+
+
+## Sponsorship Outreach VACANT
+
+* Establishing new sponsorship connections
+
+
+## National Diversity Lead VACANT
+
+* Recruiting/supporting RailsGirls Leads in Melb/Syd/Bris/Perth/Adelaide and diversity efforts
+
+
+## National Meetup Lead VACANT
+
+* Recruiting/supporting Meetup Leads in Melb/Syd/Bris/Perth/Adelaide and Book Club/Meditation
+
+
+## National Events Lead VACANT
+
+* Recruiting/supporting RubyConf and Retreat Leads and volunteers.
+
+
+## Technology Lead
+
+* Either directly or via recruitment supporting/maintaining Slack Admin/Web/Ops requirements
+
+
+## Communications Lead VACANT
+
+* Either directly or via recruitment supporting/maintaining Newsletter/Social Media/Slack Coms

--- a/app/views/pages/committee-roles.html.erb
+++ b/app/views/pages/committee-roles.html.erb
@@ -1,0 +1,5 @@
+<div class="container mx-auto prose px-4 py-10">
+  <div class="markdown max-w-full md:max-w-3xl lg:max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8 lg:py-10">
+    <%= document_markdown_to_html "committee_roles" %>
+  </div>
+</div>


### PR DESCRIPTION
Fixes #375.

Using level 1 & 2 headings gives something like this:

<img width="626" height="662" alt="Screenshot 2025-09-30 at 14 18 54" src="https://github.com/user-attachments/assets/69e4ba3d-4d3a-45e0-8aee-78d350eca314" />

