### PR TITLE
Make links in prose red and underlined

### DIFF
--- a/app/frontend/stylesheets/application.scss
+++ b/app/frontend/stylesheets/application.scss
@@ -76,6 +76,7 @@
     @apply bg-white/40 px-2 rounded-lg text-white font-bold hover:text-pearl transition-colors underline;
   }
 
+  .prose a,
   .white-link {
     @apply text-ruby-red hover:text-red-400 transition-colors underline;
   }


### PR DESCRIPTION
Currently, any anchor tags used side a prose class are not styled. If not for the change of cursor on hover, they would be indistinguishable from surrounding text

### Before

<img width="815" height="476" alt="Screenshot 2025-10-08 at 11 46 46" src="https://github.com/user-attachments/assets/7f7e52c3-9102-4cc9-98b6-5b2b9ba2bca0" />

### After

<img width="818" height="471" alt="Screenshot 2025-10-08 at 11 46 36" src="https://github.com/user-attachments/assets/870354fc-5cde-4080-95f3-be756b1a304f" />
