### PR TITLE
Require yarn command to succeed in bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -22,7 +22,7 @@ FileUtils.chdir APP_ROOT do
 
   # Install JavaScript dependencies
   puts "\n== Installing JS packages =="
-  system('bin/yarn')
+  system! "bin/yarn"
 
   puts "\n== Preparing database =="
   system! "bin/rails db:prepare"


### PR DESCRIPTION
I was following the instructions in the readme to set up the project, and ran `bin/setup`, but didn't notice the `yarn` step had failed. Upon attemping to push a Markdown change, the pre-push hook then told me the tests failed:

```
  1) PagesController on GET to /committee-members responds with success and render template
     Failure/Error: <%= vite_image_tag "images/committee-members/#{member['photo']}", class: "w-full h-auto aspect-square object-cover rounded-t-lg", alt: "Photo of #{member['name']}" %>

     ActionView::Template::Error:
       Vite Ruby can't find images/committee-members/nick-wolf.jpg in the manifests.

       Possible causes:
         - The last build failed. Try running `bin/vite build --clear --mode=test` manually and check for errors.

       Errors:
         No version is set for command yarn
         Consider adding one of the following versions in your config file at /Users/brendan.weibrecht/projects/ruby_au/.tool-versions
         yarn 1.22.19

       Visit the Troubleshooting guide for more information:
         https://vite-ruby.netlify.app/guide/troubleshooting.html#troubleshooting
```

Given working yarn is required for the tests, let's make that a setup requirement.