### PR TITLE
Vertically align sponsors

### DIFF
--- a/app/views/shared/_section-sponsors.html.erb
+++ b/app/views/shared/_section-sponsors.html.erb
@@ -11,7 +11,7 @@
 
     <div class="flex flex-wrap justify-center gap-4 sm:gap-6 md:gap-8">
       <% sponsors.each do |sponsor| %>
-        <div class="p-2 sm:p-3 md:p-4 bg-white rounded-lg shadow-sm hover:shadow-md transition-shadow">
+        <div class="p-2 sm:p-3 md:p-4 content-center bg-white rounded-lg shadow-sm hover:shadow-md transition-shadow">
           <%= link_to "/sponsors/#{sponsor['key']}" do %>
             <%= vite_image_tag "images/sponsors/#{sponsor['images'].first}",
                                 alt: sponsor['name'],


### PR DESCRIPTION
This is a visual change to improve the appearance of sponsor logos on the homepage by vertically centering them within their containers.

The PR also removes Up-specific code. Up was removed from the sponsorship file in 20909fe on 11 Dec 2024. Since they are no longer a sponsor, so we can stop maintaining code for their logo