### PR TITLE
Issue 365: add links section to footer, move some community items and add OWASP link

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -33,11 +33,19 @@
 
       <div class="text-center sm:text-left">
         <h3 class="font-bold text-base sm:text-lg mb-3">Events</h3>
-        <ul class="space-y-2">
+        <ul class="space-y-2 mb-8">
           <li><%= link_to "Ruby Retreat", "https://rails.camp", class: "footer-link" %></li>
           <li><%= link_to "RubyConf AU", "https://rubyconf.org.au", class: "footer-link" %></li>
           <li><%= link_to "Meetups", events_path, class: "footer-link" %></li>
           <li><%= link_to "Rails Girls", "/rails-girls", class: "footer-link" %></li>
+        </ul>
+        <h3 class="font-bold text-base sm:text-lg mb-3">Community</h3>
+        <ul class="space-y-2">
+          <li><%= link_to "Chat (Slack)", my_slack_invite_path, class: "white-link" %></li>
+          <li><%= link_to "Videos", videos_path, class: "white-link" %></li>
+          <li><%= link_to "RubyAU Merch", merch_path, class: "white-link" %></li>
+          <li><%= link_to "Ruby New Zealand", "https://ruby.nz/", class: "white-link" %></li>
+          <li><%= link_to "Ruby Central", "https://rubycentral.org/", class: "white-link" %></li>
         </ul>
       </div>
 
@@ -52,13 +60,8 @@
       </div>
 
       <div class="text-center sm:text-left">
-        <h3 class="font-bold text-base sm:text-lg mb-3">Community</h3>
+        <h3 class="font-bold text-base sm:text-lg mb-3">Links</h3>
         <ul class="space-y-2">
-          <li><%= link_to "Chat (Slack)", my_slack_invite_path, class: "white-link" %></li>
-          <li><%= link_to "Videos", videos_path, class: "white-link" %></li>
-          <li><%= link_to "RubyAU Merch", merch_path, class: "white-link" %></li>
-          <li><%= link_to "Ruby New Zealand", "https://ruby.nz/", class: "white-link" %></li>
-          <li><%= link_to "Ruby Central", "https://rubycentral.org/", class: "white-link" %></li>
           <li><%= link_to "Ruby on Rails", "https://rubyonrails.org/", class: "white-link" %></li>
           <li><%= link_to "RubyGems", "https://rubygems.org/", class: "white-link" %></li>
           <li><%= link_to "Ruby Language", "https://www.ruby-lang.org/", class: "white-link" %></li>


### PR DESCRIPTION
This PR addresses https://github.com/rubyaustralia/ruby_au/issues/365 by adding a link to the Rails OWASP cheat sheet.   

In addition: 
- The `community` section has been split into two sections - `community` and `links`. 
- `Community` has been moved to appear under `events`.

These changes better reflect the contents. 

## Screenshot - Mobile 

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/d8a7cfb7-3d18-43a4-93dc-75b846c80f32" />

## Screenshot - Desktop 

<img width="400" alt="image" src="https://github.com/user-attachments/assets/6715ce45-3068-43ff-b874-b1277ee273a1" />

