### PR TITLE
Fix inconsistent spacing above 'become a member' button

### DIFF
--- a/app/views/shared/_spacer-rubyau-signup.html.erb
+++ b/app/views/shared/_spacer-rubyau-signup.html.erb
@@ -6,7 +6,7 @@
     Would you like to become a member of Ruby Australia? it's free to
     <%= link_to 'join', new_user_registration_path, class: "text-white hover:text-red-400 transition-colors underline" %>.
   </div>
-  <div>
+  <div class="mt-6 sm:mt-8 md:mt-10 flex justify-center">
     <%= link_to 'Become a Member', new_user_registration_path, class: "inline-block bg-ruby-red hover:bg-red-700 border border-white border-2 text-pearl font-medium py-2 px-4 sm:py-3 sm:px-6 rounded-lg transition-colors shadow-md" %>
   </div>
 </section>


### PR DESCRIPTION
When not logged into https://ruby.org.au/, there is a `Become a member` section that appears twice and has odd button spacing (compared to what is around it) which this PR fixes.

I duplicated css settings from `_spacer-events.html.erb` for more consistent look

### before - mobile

<img width="400" alt="Connecting Online" src="https://github.com/user-attachments/assets/93384e1e-fe24-4811-ba9c-380c97a17ab5" />



### after - mobile

<img width="400" alt="Connecting Online" src="https://github.com/user-attachments/assets/c077b937-4636-44c5-8aa6-72d244c2cf0e" />



### before - desktop

<img width="800" alt="Need mental health support" src="https://github.com/user-attachments/assets/f7f6071f-7487-4371-92af-63c1344fe965" />



### after - desktop 

<img width="800" alt="CleanShot 2025-12-31 at 17 14 07@2x" src="https://github.com/user-attachments/assets/0f3cbaae-cf9d-492c-9bf8-690f1cf95534" />
