### PR TITLE
Add search to admin member list

### DIFF
--- a/app/controllers/admin/memberships_controller.rb
+++ b/app/controllers/admin/memberships_controller.rb
@@ -1,5 +1,11 @@
 class Admin::MembershipsController < Admin::ApplicationController
   expose(:members) do
-    Membership.current.visible.includes(:user).order(:full_name).page params[:page]
+    memberships = Membership.current.visible.includes(:user).order(:full_name).page(params[:page])
+    next memberships if params[:q].blank?
+
+    memberships.where(
+      %("users"."email" ILIKE :q OR "users"."full_name" ILIKE :q),
+      q: "%#{ActiveRecord::Base.sanitize_sql_like(params[:q])}%"
+    )
   end
 end

--- a/app/frontend/controllers/admin/memberships_controller.js
+++ b/app/frontend/controllers/admin/memberships_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from "@hotwired/stimulus"
+import { debounce } from "../../utils/debounce"
+
+export default class extends Controller {
+  connect() {
+    this.debouncedSubmit = debounce((event) => {
+      event.target.closest("form").requestSubmit()
+    }, 250)
+  }
+
+  submitForm(event) {
+    this.debouncedSubmit(event)
+  }
+}

--- a/app/frontend/utils/debounce.js
+++ b/app/frontend/utils/debounce.js
@@ -1,0 +1,37 @@
+/**
+ * Creates a debounced function that delays invoking func until after wait milliseconds
+ * have elapsed since the last time the debounced function was invoked.
+ *
+ * @param {Function} func - The function to debounce
+ * @param {number} wait - The number of milliseconds to delay
+ * @param {boolean} immediate - If true, trigger the function on the leading edge instead of trailing
+ * @returns {Function} The debounced function
+ *
+ * @example
+ * const debouncedSearch = debounce((query) => {
+ *   console.log('Searching for:', query)
+ * }, 300)
+ *
+ * input.addEventListener('input', (e) => debouncedSearch(e.target.value))
+ */
+export function debounce(func, wait, immediate = false) {
+  let timeout
+
+  return function executedFunction(...args) {
+    const context = this
+
+    const later = () => {
+      timeout = null
+      if (!immediate) func.apply(context, args)
+    }
+
+    const callNow = immediate && !timeout
+
+    clearTimeout(timeout)
+    timeout = setTimeout(later, wait)
+
+    if (callNow) func.apply(context, args)
+  }
+}
+
+export default debounce

--- a/app/views/admin/memberships/index.html.erb
+++ b/app/views/admin/memberships/index.html.erb
@@ -1,12 +1,55 @@
-<div class="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-12">
+<div
+  class="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-12"
+  data-controller="admin--memberships"
+>
   <div class="mb-8 sm:mb-10 md:mb-12">
     <h2 class="text-xl sm:text-2xl md:text-3xl font-semibold text-gray-800 mb-4 sm:mb-6">
       Ruby Australia Members
     </h2>
 
-    <p class="text-gray-600 text-sm sm:text-base mb-6">
-      Showing <%= members.size %> of <%= members.total_count %> total members
-    </p>
+    <div class="flex items-center">
+      <p class="grow m-0 text-gray-600 text-sm sm:text-base">
+        Showing <%= members.size %> of <%= members.total_count %> total members
+      </p>
+
+      <div class="member-search">
+        <%= form_with(
+          url: admin_memberships_path,
+          method: :get,
+          class: "grid grid-cols-1 w-64",
+        ) do |form| %>
+          <%= form.text_field(
+            :q,
+            value: params[:q],
+            placeholder: "Search by name or email",
+            autocomplete: "off",
+            data: {
+              action: "admin--memberships#submitForm",
+              turbo_permanent: true
+            },
+            class: "
+              col-start-1 row-start-1 block w-full
+              bg-white dark:bg-white/5 dark:text-white
+              py-1.5 pr-3 pl-10 sm:pl-9
+              rounded-md shadow-sm
+              outline-1 -outline-offset-1 outline-gray-300 dark:outline-white/10
+              focus:outline-2 focus:-outline-offset-2 focus:outline-ruby-red
+              dark:focus:outline-indigo-500
+              text-base text-gray-900 placeholder:text-gray-400 dark:placeholder:text-gray-500
+              sm:text-sm/6
+            "
+          ) %>
+
+          <i
+            data-lucide="search"
+            class="
+              pointer-events-none col-start-1 row-start-1 ml-3 size-5
+              self-center text-gray-400 sm:size-4 dark:text-gray-500
+            "
+          ></i>
+        <% end %>
+      </div>
+    </div>
   </div>
 
   <div class="bg-white rounded-lg shadow-md overflow-hidden">


### PR DESCRIPTION
## Context

When reviewing applications for the Mentored Contributions Program, we need to verify that applicants are Ruby Australia members. This requires searching through the membership list by name or email.

## Changes

This PR adds a search feature to the admin memberships page that allows filtering members by name or email address.

**Backend:**

- Modified `memberships_controller.rb` to accept a `q` query parameter and filter memberships using an `ILIKE` search on both `users.email` and `users.full_name`

**Frontend:**

- Added search input field to `memberships/index.html.erb` with a search icon
- Created `admin/memberships_controller.js` Stimulus controller to handle form submission
- Implemented a debounce utility to delay search requests by 250ms for reduced server load
- Used Turbo permanent to maintain search state during pagination

## Benefits

- Quickly verify membership status for mentored contributions program applicants
- Improved admin workflow when searching for specific members
- Debounced search reduces unnecessary server requests while typing