### PR TITLE
Add CodeTriage badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ We welcome contributions of all kinds! See [CONTRIBUTING.md](CONTRIBUTING.md) fo
 
 All contributors must follow our [Code of Conduct](CODE_OF_CONDUCT.md).
 
+### CodeTriage
+
+Want to help out but not sure where to start?
+Subscribe via [CodeTriage](https://www.codetriage.com/rubyaustralia/ruby_au) to receive a regular email highlighting open issues you can help with.
+
+[![Open Source Helpers](https://www.codetriage.com/rubyaustralia/ruby_au/badges/users.svg)](https://www.codetriage.com/rubyaustralia/ruby_au)
+
 ## Known Issues / Gotchas
 
 There have been issues with implementing Trix, the JS file is temporarily in the <HEAD> from the CDN.


### PR DESCRIPTION
This repository has been registered with [CodeTriage](https://www.codetriage.com/what), a tool for helping people contribute to open source. Contributors can now subscribe to receive periodic emails highlighting open issues that need attention. This makes it easier for people to contribute in small, incremental ways without having to actively hunt for work.

This PR adds a CodeTriage badge to the Contributing section of the README.