### PR TITLE
update railsgirls links to https

### DIFF
--- a/app/views/pages/rails-girls.html.erb
+++ b/app/views/pages/rails-girls.html.erb
@@ -27,7 +27,7 @@
         <!-- Subscription Form -->
         <div class="bg-gray-50 rounded-lg p-5 sm:p-6 md:p-8">
           <h2 class="text-lg sm:text-xl font-medium text-gray-900 mb-4 sm:mb-5">Join Our Mailing List</h2>
-          <%= form_tag "http://rubyaustralia.createsend.com/t/j/s/qtheu/", id: "subForm", class: "space-y-4 sm:space-y-5" do %>
+          <%= form_tag "https://rubyaustralia.createsend.com/t/j/s/qtheu/", id: "subForm", class: "space-y-4 sm:space-y-5" do %>
             <div class="space-y-1.5">
               <%= label_tag "cm-name", "Name", class: "block text-sm sm:text-base font-medium text-gray-700" %>
               <%= text_field_tag "cm-name", nil, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-ruby-red focus:ring-ruby-red sm:text-sm", placeholder: "Your name" %>
@@ -120,7 +120,7 @@
         <a href="#subForm" class="inline-flex items-center px-5 py-2.5 border border-transparent text-sm sm:text-base font-medium rounded-md shadow-sm text-ruby-red bg-white hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-ruby-red focus:ring-white transition-colors">
           Subscribe Now
         </a>
-        <a href="http://railsgirls.com/" target="_blank" rel="noopener" class="inline-flex items-center px-5 py-2.5 border border-white text-sm sm:text-base font-medium rounded-md text-white hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-ruby-red focus:ring-white transition-colors">
+        <a href="https://railsgirls.com/" target="_blank" rel="noopener" class="inline-flex items-center px-5 py-2.5 border border-white text-sm sm:text-base font-medium rounded-md text-white hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-ruby-red focus:ring-white transition-colors">
           Learn More
         </a>
       </div>

--- a/sites/melbourne/app/views/layouts/melbourne/_navigation.html.erb
+++ b/sites/melbourne/app/views/layouts/melbourne/_navigation.html.erb
@@ -15,7 +15,7 @@
         <%= link_to "Events", events_path, class: class_names("hover:underline", "underline" => current_page?(controller: :events, action: :index)) %>
       </div>
 
-      <%= link_to "ruby.org.au", "http://ruby.org.au", target: "_blank", class: "text-white/70 text-sm underline hover:text-white/90" %>
+      <%= link_to "ruby.org.au", "https://ruby.org.au", target: "_blank", class: "text-white/70 text-sm underline hover:text-white/90" %>
     </div>
   </div>
 </nav>


### PR DESCRIPTION
Fix a couple of `http` links that seem like they should be `https`

https://railsgirls.com/
https://rubyaustralia.createsend.com/t/j/s/qtheu/
https://ruby.org.au

I'm not sure if it will fix the bug shown here https://github.com/rubyaustralia/ruby_au/issues/423 where after adding myself to the mailing list I get a blank screen, no confirmation, no way to tell if the add has worked. (clarifying: this is not fixed for me when I try this locally)

However, it should address the security warnings shown in that bug report at least 🤷 

