### PR TITLE
Add contributor docs to explain how to log in to site with seeded accounts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ This starts Foreman with Vite (frontend assets), Puma (Rails server), and backgr
 
 | Account Type | Email | Password | Comments |
 | --- | --- | --- | --- | 
-| Comittee Member | `committee@example.com` | `password123` | Has access to administration features eg `Posts`, `Campaigns` |
+| Committee Member | `committee@example.com` | `password123` | Has access to administration features eg `Posts`, `Campaigns` |
 | Member | `jobseeker@example.com` | `password123` | In `Profile`, has job seeking status of `Currently Seeking Work` |
 
 ---


### PR DESCRIPTION
Follow up to https://github.com/rubyaustralia/ruby_au/pull/421 to add docs to explain how to new contributors how to log in to site with seeded accounts. 
