### PR TITLE
Create secondary email address when seeding users

### DIFF
--- a/db/seeds/users.rb
+++ b/db/seeds/users.rb
@@ -23,7 +23,7 @@ def add_secondary_email_if_not_present(user:)
 
   secondary_email_address = user.email.gsub('@', "_secondary@")
   user.emails.create!(
-    email: user.email.gsub('@', "_secondary@"),
+    email: secondary_email_address,
     primary: false,
     confirmed_at: Time.current,
     skip_trigger_after_confirmation: true


### PR DESCRIPTION
Currently there is [a bug](https://github.com/rubyaustralia/ruby_au/issues/398) relating to newsletters being sent to all a user's email addresses, rather than just the primary address. 

This PR does not fix that 😆 but adds secondary email addresses when seeding the database. This better reflects real conditions (that users can have multiple email addresses) and may reduce steps required to replicate the bug before someone can fix it.

**Secondary email address is included in the seed scripts output** 

<img width="800" alt="CleanShot 2026-01-17 at 15 33 30@2x" src="https://github.com/user-attachments/assets/15e5b86d-dadd-4450-a1a8-cb85996996c2" />

**Secondary email address as displayed in the UI** 

<img width="800" alt="Membership Details" src="https://github.com/user-attachments/assets/913bf451-f7fd-413e-b377-d975ac8c37a6" />

