### PR TITLE
Set up a custom url for Ruby Australia community project list

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -62,6 +62,7 @@
       <div class="text-center sm:text-left">
         <h3 class="font-bold text-base sm:text-lg mb-3">Links</h3>
         <ul class="space-y-2">
+          <li><%= link_to 'Community Contributions', "/contributions", class: "white-link" %></li>
           <li><%= link_to "Ruby on Rails", "https://rubyonrails.org/", class: "white-link" %></li>
           <li><%= link_to "RubyGems", "https://rubygems.org/", class: "white-link" %></li>
           <li><%= link_to "Ruby Language", "https://www.ruby-lang.org/", class: "white-link" %></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,6 +87,7 @@ Rails.application.routes.draw do
   # Off-site Redirection routes
   get '/forum', to: redirect('https://forum.ruby.org.au'), as: :forum
   get '/mailing-list', to: redirect('https://confirmsubscription.com/h/j/3DDD74A0ACC3DB22'), as: :roro_mailing_list
+  get '/contributions', to: redirect('https://github.com/orgs/rubyaustralia/projects/14'), as: :community_contributions
   get '/slack', to: redirect("/my/slack_invite")
   get '/videos', to: redirect('https://www.youtube.com/@RubyAustralia'), as: :videos
   get '/merch', to: redirect('https://www.redbubble.com/people/ruby-au/explore'), as: :merch


### PR DESCRIPTION
addresses https://github.com/rubyaustralia/ruby_au/issues/374

add route /contributions

which redirects to [project management board on github](https://github.com/orgs/rubyaustralia/projects/14) from link in footer labelled "Community Contributions"

Discussion: maybe it's better to put this link in "Community" and just have it labelled "Contributions"

<img width="800" alt="CleanShot 2026-01-24 at 09 07 23@2x" src="https://github.com/user-attachments/assets/104f3139-4da4-443f-a632-b77c5c9e71fc" />


