### PR TITLE
Fix invalid ERB nesting in admin elections index

### DIFF
--- a/app/views/admin/elections/index.html.erb
+++ b/app/views/admin/elections/index.html.erb
@@ -63,6 +63,6 @@
           </div>
         </div>
       <% end %>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
 </div>


### PR DESCRIPTION
The `<div class="bg-white ...">` table container in the admin elections index was opened inside the `<% else %>` branch but closed after the branch's `<% end %>`. This crossed the ERB block boundary, producing improperly nested HTML+ERB that fails Herb's linter (`yarn herb:lint`, part of `bin/tests`).