### PR TITLE
Run Herb lint in CI to match pre-push hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Lint Ruby code
         run: bundle exec rubocop
 
+      - name: Lint ERB code
+        run: yarn herb:lint
+
       - name: Wait for Database
         run: |
           until pg_isready --host=127.0.0.1 --port=5432 --username=ruby_au; do

--- a/.herb.yml
+++ b/.herb.yml
@@ -11,8 +11,6 @@
 # GitHub Repo: https://github.com/marcoroth/herb
 #
 
-version: 0.8.6
-
 # files:
 #   # Additional patterns beyond the defaults (**.html, **.rhtml, **.html.erb, etc.)
 #   include:


### PR DESCRIPTION
The pre-push hook runs bin/tests (rspec, rubocop, herb:lint) but CI only ran rubocop and rspec. ERB/Herb violations could therefore reach main undetected while still blocking local pushes. Add a herb:lint step to CI so it enforces the same checks as the hook.