### PR TITLE
Only load Herb in development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'warden' # use for auth
 gem 'vite_rails'
 gem 'ahoy_matey' # analytics
 gem 'geocoder' # geo location for ahoy
-gem 'herb'
+
 # background jobs
 gem 'solid_queue'
 
@@ -60,6 +60,7 @@ group :development do
   gem "annotaterb"
   gem "bullet"
   gem "callback_hell"
+  gem 'herb'
   # Access an IRB console on exception pages or by using <%= console %> in views
   gem 'listen'
   # Spring speeds up development by keeping your application running in the


### PR DESCRIPTION
Herb is configured to provide linting and formatting, both non-production features. Not running Herb in production will save a small amount of memory