### PR TITLE
Align RuboCop TargetRubyVersion with .ruby-version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,7 +17,7 @@ AllCops:
     - 'node_modules/**/*'
     - 'tmp/**/*'
   DisplayCopNames: true
-  TargetRubyVersion: 3.4
+  TargetRubyVersion: 4.0
   NewCops: disable
 
 RSpec/DescribeClass:

--- a/bin/rubocop
+++ b/bin/rubocop
@@ -2,7 +2,4 @@
 require "rubygems"
 require "bundler/setup"
 
-# explicit rubocop config increases performance slightly while avoiding config confusion.
-ARGV.unshift("--config", File.expand_path("../.rubocop.yml", __dir__))
-
 load Gem.bin_path("rubocop", "rubocop")


### PR DESCRIPTION
The `.ruby-version` file specifies Ruby 4.0.0, but `.rubocop.yml`'s AllCops/TargetRubyVersion was still set to 3.4. This caused RuboCop to lint against an older Ruby's syntax and idioms than the project actually runs, so version-specific cops were applied inconsistently.

I also found that `bin/rubocop` and `bundle exec rubocop` were behaving differently. The binstub passed `--config .rubocop.yml` explicitly, which disables RuboCop's per-directory config discovery and applies the root config to every file. This bypassed nested configs like `sites/melbourne/.rubocop.yml`, so `bin/rubocop` reported RSpec/SpecFilePathFormat offenses that `bundle exec rubocop` correctly ignored.