### PR TITLE
Return devise-multi_email to official release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'bugsnag'
 gem 'createsend'
 gem 'decent_exposure'
 gem 'devise'
-gem 'devise-multi_email', github: 'rubyaustralia/devise-multi_email', branch: 'main'
+gem 'devise-multi_email'
 gem 'friendly_id', '>= 5.5'
 gem 'icalendar'
 gem "image_processing", "~> 1.13"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/rubyaustralia/devise-multi_email.git
-  revision: 8af332653e087cbbb6b6a411a1bda34bb54e167a
-  branch: main
-  specs:
-    devise-multi_email (3.0.1)
-      devise
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -154,6 +146,8 @@ GEM
       railties (>= 7.0)
       responders
       warden (~> 1.2.3)
+    devise-multi_email (4.0.1)
+      devise (< 6.0)
     diff-lcs (1.6.2)
     docile (1.4.1)
     drb (2.2.3)
@@ -243,7 +237,7 @@ GEM
     jbuilder (2.15.0)
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
-    json (2.19.5)
+    json (2.19.7)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.2)
@@ -588,7 +582,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.8.1)
+    zeitwerk (2.8.2)
 
 PLATFORMS
   aarch64-linux
@@ -617,7 +611,7 @@ DEPENDENCIES
   debug
   decent_exposure
   devise
-  devise-multi_email!
+  devise-multi_email
   factory_bot_rails
   faker
   friendly_id (>= 5.5)


### PR DESCRIPTION
Switch back from the rubyaustralia fork to the published gem now that upstream maintenance has resumed. Tracks the official release (4.0.1), which supersedes the 3.0.1 we'd pinned the fork to.