### PR TITLE
Remove obsolete rails_12factor gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,10 +34,6 @@ gem 'solid_queue'
 # Add HTTP asset caching/compression and X-Sendfile acceleration to Puma [https://github.com/basecamp/thruster/]
 gem "thruster", require: false
 
-group :production do
-  gem 'rails_12factor'
-end
-
 group :development, :test do
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
   gem "brakeman", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -408,11 +408,6 @@ GEM
     rails-html-sanitizer (1.7.0)
       loofah (~> 2.25)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.5)
     railties (8.1.3)
       actionpack (= 8.1.3)
       activesupport (= 8.1.3)
@@ -643,7 +638,6 @@ DEPENDENCIES
   rack-mini-profiler
   rails (>= 8.0.0)
   rails-controller-testing
-  rails_12factor
   redcarpet
   rouge
   rspec-rails


### PR DESCRIPTION
The rails_12factor gem is no longer needed on Rails 5+ (per Heroku's own README). It bundled rails_serve_static_assets and rails_stdout_logging, both of which this Rails 8 app already configures explicitly in config/environments/production.rb:

  - config.logger routes to $stdout
  - config.public_file_server.enabled = true

The gem was therefore redundant, so removing it requires no config changes and leaves runtime behavior unchanged.