### PR TITLE
Remove unused inline_svg gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ gem 'devise-multi_email', github: 'rubyaustralia/devise-multi_email', branch: 'm
 gem 'friendly_id', '>= 5.5'
 gem 'icalendar'
 gem "image_processing", "~> 1.13"
-gem 'inline_svg', '~> 1.10.0'
 gem 'jbuilder'
 gem 'kaminari'
 gem 'premailer-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,9 +231,6 @@ GEM
     image_processing (1.14.0)
       mini_magick (>= 4.9.5, < 6)
       ruby-vips (>= 2.0.17, < 3)
-    inline_svg (1.10.0)
-      activesupport (>= 3.0)
-      nokogiri (>= 1.6)
     io-console (0.8.2)
     irb (1.18.0)
       pp (>= 0.6.0)
@@ -627,7 +624,6 @@ DEPENDENCIES
   herb
   icalendar
   image_processing (~> 1.13)
-  inline_svg (~> 1.10.0)
   jbuilder
   kaminari
   letter_opener


### PR DESCRIPTION
The inline_svg gem was declared but never used — none of its helpers (inline_svg, inline_svg_tag, etc.) are called anywhere in the app. SVG inlining is handled by the custom vite_inline_svg helper in SvgHelper, which reads files directly and processes them with Nokogiri and Rails' sanitize, fitting the Vite asset setup.