### PR TITLE
Add job seekers link in footer-contact

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -24,6 +24,7 @@
         <h3 class="font-bold text-base sm:text-lg mb-3">Contact</h3>
         <ul class="space-y-2">
           <li><%= link_to 'News', posts_path, class: "footer-link" %></li>
+          <li><%= link_to 'Job Seekers', '/job-seekers', class: "footer-link" %></li>
           <li><%= link_to "Feedback", "/feedback", class: "footer-link" %></li>
           <li><%= link_to "Contact us", "/contact", class: "footer-link" %></li>
           <li><%= link_to 'Committee Members', "/committee-members", class: "footer-link" %></li>


### PR DESCRIPTION
@leesheppard and Simon,
I worked on issue #479 . Please refer below and review this PR.

- Change: I added a link to the job seekers list in the contact section in footer.
- The related issue is here: https://github.com/rubyaustralia/ruby_au/issues/479
