### PR TITLE
Presidents Timeline in Committee Members Page

### DIFF
--- a/app/frontend/stylesheets/application.scss
+++ b/app/frontend/stylesheets/application.scss
@@ -169,3 +169,10 @@
 .aspect-video {
   aspect-ratio: 16 / 9;
 }
+  
+.presidents {
+  h2 {
+    @apply text-2xl font-extrabold text-ruby-red mb-10;
+    font-family: "Merriweather", serif;
+  }
+}

--- a/app/helpers/committee_helper.rb
+++ b/app/helpers/committee_helper.rb
@@ -8,7 +8,18 @@ module CommitteeHelper
     previous_committee = YAML.load_file Rails.root.join('config/data/previous.yml')
 
     (current_committee + previous_committee)
-      .filter { |member| member['position'].downcase == 'president' || member['position'].downcase.split(',').any? { |post| post.gsub(/\([^)]*\)/, '').strip == 'president' } }
-      .map { |p| { name: p['name'], start: p['start'].is_a?(Array) ? p['start'] : [p['start']], end: p['end'].is_a?(Array) ? p['end'] : [p['end']] } }
+      .filter { |member| president?(member) }
+      .map { |p| { name: p['name'], start: to_array(p['start']), end: to_array(p['end']) } }
+  end
+
+  private
+
+  def president?(member)
+    member['position'].downcase == 'president' ||
+      member['position'].downcase.split(',').any? { |position| position.gsub(/\([^)]*\)/, '').strip == 'president' }
+  end
+
+  def to_array(term)
+    term.is_a?(Array) ? term : [term]
   end
 end

--- a/app/helpers/committee_helper.rb
+++ b/app/helpers/committee_helper.rb
@@ -16,14 +16,9 @@ module CommitteeHelper
 
     min_term = Date.parse(presidents_data[-1][:start][0])
     max_term = Date.parse(presidents_data[0][:end][-1])
-    # all_terms = max_term - min_term , all: all_terms
 
     { min_term: min_term, max_term: max_term }
   end
-
-  # term calculation to be used in view
-  # Offset: (the president start-date - min_term) / (max_term - min_term) * 100
-  # Width(duration): (the president end-date - the president start-date)/ (max_term - min_term) * 100
 
   def president_terms(president)
     starts = president[:start]
@@ -34,6 +29,14 @@ module CommitteeHelper
     starts.map.each_with_index do |start_date, index|
       calc_each_term(start_date, ends[index], min, all_terms)
     end
+  end
+
+  def chart_years
+    (presidents_years[:min_term].year..presidents_years[:max_term].year)
+  end
+
+  def year_length
+    100.0 / (presidents_years[:max_term].year - presidents_years[:min_term].year)
   end
 
   private

--- a/app/helpers/committee_helper.rb
+++ b/app/helpers/committee_helper.rb
@@ -2,4 +2,13 @@ module CommitteeHelper
   def current_committee?
     user_signed_in? && current_user.committee?
   end
+
+  def presidents
+    current_committee = YAML.load_file Rails.root.join('config/data/committee.yml')
+    previous_committee = YAML.load_file Rails.root.join('config/data/previous.yml')
+
+    (current_committee + previous_committee)
+      .filter { |member| member['position'].downcase == 'president' || member['position'].downcase.split(',').any? { |post| post.gsub(/\([^)]*\)/, '').strip == 'president' } }
+      .map { |p| { name: p['name'], start: p['start'].is_a?(Array) ? p['start'] : [p['start']], end: p['end'].is_a?(Array) ? p['end'] : [p['end']] } }
+  end
 end

--- a/app/helpers/committee_helper.rb
+++ b/app/helpers/committee_helper.rb
@@ -6,9 +6,9 @@ module CommitteeHelper
   def presidents
     president_list = load_presidents
 
-    group_presidents(president_list)
+    grouped = group_presidents(president_list)
 
-    president_list.sort! { |a, b| b[:start][-1] <=> a[:start][-1] }
+    grouped.sort! { |a, b| b[:start][-1] <=> a[:start][-1] }
   end
 
   private
@@ -29,11 +29,11 @@ module CommitteeHelper
 
       if other
         combine_records(other, record)
-        president_list.delete(record)
       else
         grouped << record
       end
     end
+    grouped
   end
 
   def combine_records(other, record)

--- a/app/helpers/committee_helper.rb
+++ b/app/helpers/committee_helper.rb
@@ -4,11 +4,9 @@ module CommitteeHelper
   end
 
   def presidents
-    president_list = load_presidents
+    grouped_presidents = group_presidents(load_presidents)
 
-    grouped = group_presidents(president_list)
-
-    grouped.sort! { |a, b| b[:start][-1] <=> a[:start][-1] }
+    grouped_presidents.sort! { |a, b| b[:start][-1] <=> a[:start][-1] }
   end
 
   def presidents_years
@@ -26,7 +24,7 @@ module CommitteeHelper
     all_terms = presidents_years[:max_term] - presidents_years[:min_term]
     min = presidents_years[:min_term]
 
-    starts.map.each_with_index do |start_date, index|
+    starts.map.with_index do |start_date, index|
       calc_each_term(start_date, ends[index], min, all_terms)
     end
   end
@@ -36,7 +34,7 @@ module CommitteeHelper
   end
 
   def year_length
-    100.0 / (presidents_years[:max_term].year - presidents_years[:min_term].year)
+    100.0 / chart_years.count
   end
 
   private

--- a/app/helpers/committee_helper.rb
+++ b/app/helpers/committee_helper.rb
@@ -4,30 +4,42 @@ module CommitteeHelper
   end
 
   def presidents
-    current_committee = YAML.load_file Rails.root.join('config/data/committee.yml')
-    previous_committee = YAML.load_file Rails.root.join('config/data/previous.yml')
+    president_list = load_presidents
 
-    president_list = (current_committee + previous_committee)
-                     .filter { |member| president?(member) }
-                     .map { |p| { name: p['name'], start: to_array(p['start']), end: to_array(p['end']) } }
-
-    grouped = []
-    president_list.each do |record|
-      multiple = grouped.find { |item| item[:name] == record[:name] }
-
-      if multiple
-        multiple[:start].concat(record[:start]).sort!
-        multiple[:end].concat(record[:end]).sort!
-        president_list.delete(record)
-      else
-        grouped << record
-      end
-    end
+    group_presidents(president_list)
 
     president_list.sort! { |a, b| b[:start][-1] <=> a[:start][-1] }
   end
 
   private
+
+  def load_presidents
+    current_committee = YAML.load_file Rails.root.join('config/data/committee.yml')
+    previous_committee = YAML.load_file Rails.root.join('config/data/previous.yml')
+
+    (current_committee + previous_committee)
+      .filter { |member| president?(member) }
+      .map { |p| { name: p['name'], start: to_array(p['start']), end: to_array(p['end']) } }
+  end
+
+  def group_presidents(president_list)
+    grouped = []
+    president_list.each do |record|
+      other = grouped.find { |item| item[:name] == record[:name] }
+
+      if other
+        combine_records(other, record)
+        president_list.delete(record)
+      else
+        grouped << record
+      end
+    end
+  end
+
+  def combine_records(other, record)
+    other[:start].concat(record[:start]).sort!
+    other[:end].concat(record[:end]).sort!
+  end
 
   def president?(member)
     member['position'].downcase == 'president' ||

--- a/app/helpers/committee_helper.rb
+++ b/app/helpers/committee_helper.rb
@@ -4,18 +4,11 @@ module CommitteeHelper
   end
 
   def presidents
-    grouped_presidents = group_presidents(load_presidents)
+    @presidents ||= begin
+      grouped_presidents = group_presidents(load_presidents)
 
-    grouped_presidents.sort! { |a, b| b[:start][-1] <=> a[:start][-1] }
-  end
-
-  def presidents_years
-    presidents_data = presidents
-
-    min_term = Date.parse(presidents_data[-1][:start][0])
-    max_term = Date.parse(presidents_data[0][:end][-1])
-
-    { min_term: min_term, max_term: max_term }
+      grouped_presidents.sort! { |a, b| b[:start][-1] <=> a[:start][-1] }
+    end
   end
 
   def president_terms(president)
@@ -74,6 +67,17 @@ module CommitteeHelper
 
   def to_array(term)
     term.is_a?(Array) ? term : [term]
+  end
+
+  def presidents_years
+    @presidents_years ||= begin
+      presidents_data = presidents
+
+      min_term = Date.parse(presidents_data[-1][:start][0])
+      max_term = Date.parse(presidents_data[0][:end][-1])
+
+      { min_term: min_term, max_term: max_term }
+    end
   end
 
   def calc_each_term(start_date, end_date, min_term, all_terms)

--- a/app/helpers/committee_helper.rb
+++ b/app/helpers/committee_helper.rb
@@ -16,9 +16,9 @@ module CommitteeHelper
 
     min_term = Date.parse(presidents_data[-1][:start][0])
     max_term = Date.parse(presidents_data[0][:end][-1])
-    all_terms = max_term - min_term
+    # all_terms = max_term - min_term , all: all_terms
 
-    { min_term: min_term, max_term: max_term, all: all_terms }
+    { min_term: min_term, max_term: max_term }
   end
 
   # term calculation to be used in view
@@ -28,17 +28,11 @@ module CommitteeHelper
   def president_terms(president)
     starts = president[:start]
     ends = president[:end]
-    all_terms = presidents_years[:all]
+    all_terms = presidents_years[:max_term] - presidents_years[:min_term]
     min = presidents_years[:min_term]
 
-    starts.each_with_index.map do |start_date, index|
-      start = Date.parse(start_date)
-      end_date = Date.parse(ends[index])
-
-      offset = (start - min) / all_terms * 100
-      presidency = (end_date - start) / all_terms * 100
-
-      { offset: offset.to_i, presidency: presidency.to_i }
+    starts.map.each_with_index do |start_date, index|
+      calc_each_term(start_date, ends[index], min, all_terms)
     end
   end
 
@@ -79,5 +73,15 @@ module CommitteeHelper
 
   def to_array(term)
     term.is_a?(Array) ? term : [term]
+  end
+
+  def calc_each_term(start_date, end_date, min_term, all_terms)
+    start_d = Date.parse(start_date)
+    end_d = Date.parse(end_date)
+
+    offset = (start_d - min_term) / all_terms * 100
+    presidency = (end_d - start_d) / all_terms * 100
+
+    { offset: offset.to_f, presidency: presidency.to_f }
   end
 end

--- a/app/helpers/committee_helper.rb
+++ b/app/helpers/committee_helper.rb
@@ -11,6 +11,37 @@ module CommitteeHelper
     grouped.sort! { |a, b| b[:start][-1] <=> a[:start][-1] }
   end
 
+  def presidents_years
+    presidents_data = presidents
+
+    min_term = Date.parse(presidents_data[-1][:start][0])
+    max_term = Date.parse(presidents_data[0][:end][-1])
+    all_terms = max_term - min_term
+
+    { min_term: min_term, max_term: max_term, all: all_terms }
+  end
+
+  # term calculation to be used in view
+  # Offset: (the president start-date - min_term) / (max_term - min_term) * 100
+  # Width(duration): (the president end-date - the president start-date)/ (max_term - min_term) * 100
+
+  def president_terms(president)
+    starts = president[:start]
+    ends = president[:end]
+    all_terms = presidents_years[:all]
+    min = presidents_years[:min_term]
+
+    starts.each_with_index.map do |start_date, index|
+      start = Date.parse(start_date)
+      end_date = Date.parse(ends[index])
+
+      offset = (start - min) / all_terms * 100
+      presidency = (end_date - start) / all_terms * 100
+
+      { offset: offset.to_i, presidency: presidency.to_i }
+    end
+  end
+
   private
 
   def load_presidents

--- a/app/helpers/committee_helper.rb
+++ b/app/helpers/committee_helper.rb
@@ -7,9 +7,24 @@ module CommitteeHelper
     current_committee = YAML.load_file Rails.root.join('config/data/committee.yml')
     previous_committee = YAML.load_file Rails.root.join('config/data/previous.yml')
 
-    (current_committee + previous_committee)
-      .filter { |member| president?(member) }
-      .map { |p| { name: p['name'], start: to_array(p['start']), end: to_array(p['end']) } }
+    president_list = (current_committee + previous_committee)
+                     .filter { |member| president?(member) }
+                     .map { |p| { name: p['name'], start: to_array(p['start']), end: to_array(p['end']) } }
+
+    grouped = []
+    president_list.each do |record|
+      multiple = grouped.find { |item| item[:name] == record[:name] }
+
+      if multiple
+        multiple[:start].concat(record[:start]).sort!
+        multiple[:end].concat(record[:end]).sort!
+        president_list.delete(record)
+      else
+        grouped << record
+      end
+    end
+
+    president_list.sort! { |a, b| b[:start][-1] <=> a[:start][-1] }
   end
 
   private

--- a/app/views/pages/committee-members.html.erb
+++ b/app/views/pages/committee-members.html.erb
@@ -1,8 +1,8 @@
 <% title "Committee Members" %>
 
 <section class="container mx-auto px-4 py-10">
-  <div class="mb-8 bg-ruby-red/6 p-[0.5rem] border border-ruby-red/20 rounded-md">
-    <h1 class="text-center text-2xl mb-4">Presidents Timeline</h1>
+  <div class="presidents mb-8 bg-ruby-red/6 p-[0.5rem] border border-ruby-red/20 rounded-md">
+    <h2 class="text-center">Presidents Timeline</h2>
     <% presidents.each do |president| %>
         <div class="flex items-stretch">
           <div class="sm:w-48 w-24 flex-shrink-0 text-lg font-semibold"><%= president[:name] %></div>

--- a/app/views/pages/committee-members.html.erb
+++ b/app/views/pages/committee-members.html.erb
@@ -1,4 +1,9 @@
 <% title "Committee Members" %>
+
+<% presidents.each do |president| %>
+    <div><%= president %></div>
+<% end %>
+
 <section class="container mx-auto px-4 py-10">
   <h1 class="text-center">Committee Members</h1>
   <div id="committee" class="flex flex-wrap justify-center gap-6 mt-8">

--- a/app/views/pages/committee-members.html.erb
+++ b/app/views/pages/committee-members.html.erb
@@ -1,24 +1,34 @@
 <% title "Committee Members" %>
 
-<% presidents.each do |president| %>
-    <div class="flex">
-      <div><%= president[:name] %></div>
-      <% president_terms(president).each do |t| %>
-      <div class="absolute bg-ruby-red" style="left: <%= t[:offset] %>%;
-                  width: <%= t[:presidency] %>%">
-        &nbsp;
-      </div>
-      <% end %>
-    </div>
-<% end %>
-  <div class="beginning">
-    <%= presidents_years[:min_term].year %>
-  </div>
-  <div class="end">
-    <%= presidents_years[:max_term].year %>
-  </div>
-
 <section class="container mx-auto px-4 py-10">
+  <div class="mb-8">
+    <h1 class="text-center text-2xl mb-4">Presidents Timeline</h1>
+    <% presidents.each do |president| %>
+        <div class="flex items-stretch">
+          <div class="w-48 flex-shrink-0 text-lg font-semibold "><%= president[:name] %></div>
+          <div class="flex-1">
+            <div class="relative">
+              <% president_terms(president).each do |t| %>
+                <div class="absolute bg-ruby-red" style="left: <%= t[:offset] %>%;
+                            width: <%= t[:presidency] %>%">
+                  &nbsp;
+                </div>
+              <% end %>
+            </div>
+          </div>
+        </div>
+    <% end %>
+
+   <div class="flex">
+    <div class="w-48 flex-shrink-0"> &nbsp;</div>
+    <% chart_years.each do |y| %>
+      <div style="width: <%= year_length %>%">
+        <%= y %>
+      </div>
+    <% end %>
+  </div>
+</div>
+  
   <h1 class="text-center">Committee Members</h1>
   <div id="committee" class="flex flex-wrap justify-center gap-6 mt-8">
     <% committee.each do |member| %>

--- a/app/views/pages/committee-members.html.erb
+++ b/app/views/pages/committee-members.html.erb
@@ -1,16 +1,16 @@
 <% title "Committee Members" %>
 
 <section class="container mx-auto px-4 py-10">
-  <div class="mb-8">
+  <div class="mb-8 bg-ruby-red/6 p-[0.5rem] border border-ruby-red/20 rounded-md">
     <h1 class="text-center text-2xl mb-4">Presidents Timeline</h1>
     <% presidents.each do |president| %>
         <div class="flex items-stretch">
-          <div class="w-48 flex-shrink-0 text-lg font-semibold "><%= president[:name] %></div>
+          <div class="sm:w-48 w-24 flex-shrink-0 text-lg font-semibold"><%= president[:name] %></div>
           <div class="flex-1">
-            <div class="relative">
+            <div class="relative min-h-6">
               <% president_terms(president).each do |t| %>
-                <div class="absolute bg-ruby-red" style="left: <%= t[:offset] %>%;
-                            width: <%= t[:presidency] %>%">
+                <div class="absolute h-full bg-ruby-red" style="left: <%= t[:offset] %>%;
+                            width: calc(<%= t[:presidency] %>% + 1px);">
                   &nbsp;
                 </div>
               <% end %>
@@ -20,9 +20,9 @@
     <% end %>
 
    <div class="flex">
-    <div class="w-48 flex-shrink-0"> &nbsp;</div>
+    <div class="sm:w-48 w-24 flex-shrink-0"> &nbsp;</div>
     <% chart_years.each do |y| %>
-      <div style="width: <%= year_length %>%">
+      <div class="sm:text-sm text-xs" style="width: <%= year_length %>%">
         <%= y %>
       </div>
     <% end %>

--- a/app/views/pages/committee-members.html.erb
+++ b/app/views/pages/committee-members.html.erb
@@ -1,8 +1,22 @@
 <% title "Committee Members" %>
 
 <% presidents.each do |president| %>
-    <div><%= president %></div>
+    <div class="flex">
+      <div><%= president[:name] %></div>
+      <% president_terms(president).each do |t| %>
+      <div class="absolute bg-ruby-red" style="left: <%= t[:offset] %>%;
+                  width: <%= t[:presidency] %>%">
+        &nbsp;
+      </div>
+      <% end %>
+    </div>
 <% end %>
+  <div class="beginning">
+    <%= presidents_years[:min_term].year %>
+  </div>
+  <div class="end">
+    <%= presidents_years[:max_term].year %>
+  </div>
 
 <section class="container mx-auto px-4 py-10">
   <h1 class="text-center">Committee Members</h1>

--- a/app/views/pages/previous-committee-members.html.erb
+++ b/app/views/pages/previous-committee-members.html.erb
@@ -1,12 +1,17 @@
-<% title "Previous Committee Members" %>
+-<% title "Previous Committee Members" %>
 <section class="container mx-auto px-4 py-10">
   <h1 class="text-center">Previous Committee Members</h1>
   <div id="committee" class="flex flex-wrap w-6xl m-auto">
     <% previous.each do |member| %>
       <article class="bg-white max-w-xs rounded-lg shadow-lg m-5 flex-shrink-0 flex flex-col">
-        <figure class="overflow-hidden max-h-80">
-          <%= vite_image_tag "images/committee-members/#{member['photo']}", class: "w-full overflow-hidden rounded-t-lg", alt: "Photo of #{member['name']}" %>
-        </figure>
+       
+          <figure class="overflow-hidden max-h-80 min-w-80">
+            <% if member['photo'] %>
+              <%= vite_image_tag "images/committee-members/#{member['photo']}", class: "w-full overflow-hidden rounded-t-lg", alt: "Photo of #{member['name']}" %>
+            <% else %>
+              <div class="w-full h-80 bg-ruby-red/5 overflow-hidden rounded-t-lg"></div>
+            <% end %>
+          </figure>
         <header class="px-6 py-4">
           <div class="text-ruby-red font-bold uppercase"><%= member['name'] %></div>
           <div class="font-bold"><%= member['position'] %></div>

--- a/app/views/pages/previous-committee-members.html.erb
+++ b/app/views/pages/previous-committee-members.html.erb
@@ -1,4 +1,4 @@
--<% title "Previous Committee Members" %>
+<% title "Previous Committee Members" %>
 <section class="container mx-auto px-4 py-10">
   <h1 class="text-center">Previous Committee Members</h1>
   <div id="committee" class="flex flex-wrap w-6xl m-auto">

--- a/config/data/committee.yml
+++ b/config/data/committee.yml
@@ -1,6 +1,8 @@
 - name: Nick Wolf
   photo: nick-wolf.jpg
   position: President
+  start: "2025-10-18"
+  end: "2026-10-17"
   twitter: quintrino
   github: quintrino
   website: https://nickwolf.com.au

--- a/config/data/previous.yml
+++ b/config/data/previous.yml
@@ -116,6 +116,12 @@
 - name: Pat Allan
   photo: pat-allan-new.jpg
   position: President
+  start: 
+    - "2018-12-18"
+    - "2019-10-15"
+  end:
+    - "2019-10-14"
+    - "2020-10-11"
   bio: |
     Pat is a gelato connoisseur, pancake master, and occasional events organiser (including [RubyConf AU](https://rubyconf.org.au), [Rails Camps](https://rails.camp), and [Trampoline](https://trampolineday.com)). Mostly, though, he is a contracting Ruby developer based in Melbourne, and most recently has led the development efforts at [Limbr](https://limbr.org), a social enterprise focused on mental health.
   twitter: pat
@@ -182,6 +188,8 @@
 - name: Toby Nieboer
   photo: toby-nieboer.jpg
   position: President, Vice President
+  start: "2017-11-12"
+  end: "2018-12-17"
   bio: |
     Toby was a developer and dev manager for nine years before moving into recruitment. These days he hires software engineers for [Automattic](https://automattic.com), and is also the co-organiser of the [Melbourne Ruby meetup](https://www.meetup.com/Ruby-On-Rails-Oceania-Melbourne). In his spare time he is a gadget hoarder, mac & cheese enthusiast and dad.
   twitter: tcn33
@@ -189,7 +197,19 @@
 
 - name: Nick Wolf
   photo: nick-wolf.jpg
-  position: Secretary, General Member
+  position: President, Secretary, General Member
+  start: 
+    - "2020-10-12"
+    - "2021-11-29"
+    - "2022-11-28"
+    - "2023-10-19"
+    - "2024-10-19"
+  end:
+    - "2021-11-28"
+    - "2022-11-27"
+    - "2023-10-18"
+    - "2024-10-18"
+    - "2025-10-17"
   bio: |
     Nick is a Melbourne Junior Ruby Dev who is passionate about Community Media and how technology is changing what it is to be human. He formerly hosted "The Year in Geek", a radio show interviewing 24 Geeks over a marathon 24 hours on topics ranging from Anime, Behavioural Economics and Formula One.
   twitter: quintrino
@@ -216,6 +236,8 @@
 - name: Lauren Hennessy
   photo: lauren-hennessy.jpg
   position: President, Vice President, General Member
+  start: "2016-12-11"
+  end: "2017-11-11"
   bio: |
     A junior developer and community evangelist, Lauren is a seasoned organiser of Ruby events both large and small. After a long while contributing to the community in her home town of Adelaide, she now resides in Melbourne and flounders around with code at [Culture Amp](http://www.cultureamp.com). She’s passionate about fostering diversity and growth in the Ruby community and is excited to be leading the committee in those pursuits.
 
@@ -247,6 +269,8 @@
 - name: Leonard Garvey
   photo: leonard-garvey.jpg
   position: President
+  start: "2015-12-13"
+  end: "2016-12-10"
   bio: |
     Len has been a part of the Sydney Ruby community for several years. He organised Rails Camp 17 at Broken Bay north of Sydney and recently moved to Melbourne to take up a Tech Lead position with [REA](http://www.rea-group.com/). He enjoys helping new people in the Ruby community and is working to make it a fun and welcoming place for all.
 
@@ -315,6 +339,8 @@
 - name: Sebastian von Conrad
   photo: sebastian-avatar.jpg
   position: President, Treasurer (2012)
+  start: "2014-11-15"
+  end: "2015-12-12"
   bio: |
     After growing up in Sweden, Sebastian escaped to the US in 2007 and moved down under in 2009. He now lives in Melbourne with his partner and two fur children, and works as a development manager at [Envato](http://www.envato.com). He is also a certified baseball nut. Having organised Rails Camp X, he is excited to continue working with the Australian Ruby community.
   twitter: vonconrad
@@ -430,6 +456,8 @@
 - name: Ben Schwarz
   photo: ben-avatar.jpg
   position: President (2014), General Member (2012)
+  start: "2013-02-01"
+  end: "2013-11-02"
   twitter: benschwarz
   website: http://germanforblack.com
 
@@ -461,6 +489,8 @@
 - name: Keith Pitty
   photo: keith-avatar.jpg
   position: President (2012)
+  start: "2011-06-16"
+  end: "2012-06-15"
   bio: |
     A long-time participant, former convener of and occasional presenter at Sydney Ruby meetups, Keith led the organisation of Rails Camp 9 at Lake Ainsworth in 2011 and co-organised the inaugural [RubyConf AU](http://rubyconf.org.au) in Melbourne in 2013. He runs [Cockatoo Software](http://www.cockatoosoftware.com.au).
 
@@ -492,7 +522,14 @@
 - name: Nigel Rausch
   photo: nigel-avatar.jpg
   position: President (2012)
+  start: "2012-06-16"
+  end: "2013-01-31"
   bio: |
     Nigel has a strong community spirit and is heavily involved organising Brisbane's Ruby, Javascript and WorkAtJelly meetups as well as mentoring friends and ex-colleagues in their business ventures.
 
     He is proud to be part of the Ruby Australia Association and is excited how it will make Ruby more visible to the wider community and to the Enterprise.
+
+- name: Matt Allen
+  position: President
+  start: "2013-11-03"
+  end: "2014-11-14"

--- a/config/data/previous.yml
+++ b/config/data/previous.yml
@@ -530,6 +530,7 @@
     He is proud to be part of the Ruby Australia Association and is excited how it will make Ruby more visible to the wider community and to the Enterprise.
 
 - name: Matt Allen
+  photo:
   position: President
   start: "2013-11-03"
   end: "2014-11-14"

--- a/spec/helpers/committee_helper_spec.rb
+++ b/spec/helpers/committee_helper_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe CommitteeHelper, type: :helper do
+  describe '#presidents' do
+    it 'returns a list of presidents' do
+      expect(helper.presidents).not_to be_empty
+    end
+
+    it 'has Keith as the oldest president' do
+      expect(helper.presidents[-1][:name]).to eq('Keith Pitty')
+    end
+
+    it 'is 2012/06/16 when the second oldest president term starts' do
+      expect(helper.presidents[-2][:start][0]).to eq('2012-06-16')
+    end
+  end
+end

--- a/spec/helpers/committee_helper_spec.rb
+++ b/spec/helpers/committee_helper_spec.rb
@@ -1,17 +1,36 @@
 require 'rails_helper'
 
 RSpec.describe CommitteeHelper, type: :helper do
+  before do
+    allow(YAML).to receive(:load_file).with(Rails.root.join('config/data/committee.yml')).and_return([{ 'name' => 'Melbourne Blue', 'position' => 'President', 'start' => %w[2026-01-01 2020-03-03], 'end' => %w[2026-12-31 2020-03-02] }])
+    allow(YAML).to receive(:load_file).with(Rails.root.join('config/data/previous.yml')).and_return([{ 'name' => 'Ruby Red', 'position' => 'president', 'start' => %w[2001-01-01 2002-03-03], 'end' => %w[2001-12-31 2003-03-02] },
+                                                                                                     { 'name' => 'Wild Boar', 'position' => 'president', 'start' => %w[2000-01-01 2005-03-03], 'end' => %w[2000-12-31 2006-03-02] }, { 'name' => 'Pig Pink', 'position' => 'president', 'start' => %w[2010-01-01 2011-03-03], 'end' => %w[2010-12-31 2012-03-02] }])
+  end
+
   describe '#presidents' do
-    it 'returns a list of presidents' do
-      expect(helper.presidents).not_to be_empty
-    end
+    it 'returns a list of presidents and terms sorted by the latest start date to the oldest start date' do
+      presidents = helper.presidents
 
-    it 'has Keith as the oldest president' do
-      expect(helper.presidents[-1][:name]).to eq('Keith Pitty')
-    end
+      expect(presidents).not_to be_empty
 
-    it 'is 2012/06/16 when the second oldest president term starts' do
-      expect(helper.presidents[-2][:start][0]).to eq('2012-06-16')
+      names = presidents.map { |p| p[:name] }
+      expect(names).to eq(['Melbourne Blue', 'Pig Pink', 'Wild Boar', 'Ruby Red'])
+
+      start_dates = presidents.map { |p| p[:start] }
+      expect(start_dates).to eq([
+                                  %w[2026-01-01 2020-03-03],
+                                  %w[2010-01-01 2011-03-03],
+                                  %w[2000-01-01 2005-03-03],
+                                  %w[2001-01-01 2002-03-03]
+                                ])
+
+      end_dates = presidents.map { |p| p[:end] }
+      expect(end_dates).to eq([
+                                %w[2026-12-31 2020-03-02],
+                                %w[2010-12-31 2012-03-02],
+                                %w[2000-12-31 2006-03-02],
+                                %w[2001-12-31 2003-03-02]
+                              ])
     end
   end
 end


### PR DESCRIPTION
I added a timeline for Ruby Australia presidential history to the current committee members page based on the idea by @ZimbiX . Please refer below and review this request.

I used the existing yml files (committee.yml for the current president and previous.yml for all of previous presidents) to get president names, term start and term end. Presidents data is sourced from forum archive, Slack announcements and commits to those yml files. All logic for this timeline lives in the committee_helper file.

- The related issue is here: https://github.com/rubyaustralia/ruby_au/issues/443
- UI Screenshot:
<img width="1510" height="622" alt="Screenshot 2026-07-18 at 4 38 32 pm" src="https://github.com/user-attachments/assets/1e99dc2a-ecdf-403d-9882-3bfdbef1244a" />
